### PR TITLE
Fix missing declare

### DIFF
--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -19,7 +19,7 @@ class TypeDefinitionWriter implements Writer
         foreach ($namespaces as $namespace => $types) {
             asort($types);
 
-            $output .= "namespace {$namespace} {".PHP_EOL;
+            $output .= "declare namespace {$namespace} {".PHP_EOL;
 
             $output .= join(PHP_EOL, array_map(
                 fn (TransformedType $type) => "export type {$type->name} = {$type->transformed};",


### PR DESCRIPTION
Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.