### PR TITLE
feat: allow Typescript enums

### DIFF
--- a/src/Structures/TransformedType.php
+++ b/src/Structures/TransformedType.php
@@ -94,14 +94,9 @@ class TransformedType
     }
 
     public function toString() {
-        switch ($this->format) {
-            case 'enum': {
-                return "enum {$this->name} { {$this->transformed} };";
-            }
-
-            default: {
-                return "type {$this->name} = {$this->transformed};";
-            }
-        }
+        return match ($this->format) {
+            'enum' => "enum {$this->name} { {$this->transformed} };",
+            default => "type {$this->name} = {$this->transformed};",
+        };
     }
 }

--- a/src/Structures/TransformedType.php
+++ b/src/Structures/TransformedType.php
@@ -95,8 +95,8 @@ class TransformedType
 
     public function toString() {
         return match ($this->format) {
-            'enum' => "enum {$this->name} { {$this->transformed} };",
-            default => "type {$this->name} = {$this->transformed};",
+            'enum' => "enum {$this->name} { {$this->transformed} }",
+            default => "type {$this->name} = {$this->transformed}",
         };
     }
 }

--- a/src/Structures/TransformedType.php
+++ b/src/Structures/TransformedType.php
@@ -16,14 +16,17 @@ class TransformedType
 
     public bool $isInline;
 
+    public string $format;
+
     public static function create(
         ReflectionClass $class,
         string $name,
         string $transformed,
         ?MissingSymbolsCollection $missingSymbols = null,
-        bool $inline = false
+        bool $inline = false,
+        string $format = 'type'
     ): self {
-        return new self($class, $name, $transformed, $missingSymbols ?? new MissingSymbolsCollection(), $inline);
+        return new self($class, $name, $transformed, $missingSymbols ?? new MissingSymbolsCollection(), $inline, $format);
     }
 
     public static function createInline(
@@ -39,13 +42,15 @@ class TransformedType
         ?string $name,
         string $transformed,
         MissingSymbolsCollection $missingSymbols,
-        bool $isInline
+        bool $isInline,
+        string $format = 'type'
     ) {
         $this->reflection = $class;
         $this->name = $name;
         $this->transformed = $transformed;
         $this->missingSymbols = $missingSymbols;
         $this->isInline = $isInline;
+        $this->format = $format;
     }
 
     public function getNamespaceSegments(): array
@@ -86,5 +91,17 @@ class TransformedType
             $replacement,
             $this->transformed
         );
+    }
+
+    public function toString() {
+        switch ($this->format) {
+            case 'enum': {
+                return "enum {$this->name} { {$this->transformed} };";
+            }
+
+            default: {
+                return "type {$this->name} = {$this->transformed};";
+            }
+        }
     }
 }

--- a/src/Transformers/EnumNativeTransformer.php
+++ b/src/Transformers/EnumNativeTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Transformers;
+
+use ReflectionClass;
+use ReflectionEnum;
+use ReflectionEnumUnitCase;
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
+
+class EnumNativeTransformer implements Transformer
+{
+    public function transform(ReflectionClass $class, string $name): ?TransformedType
+    {
+        // If we're not on PHP >= 8.1, we don't support native enums.
+        if (! method_exists($class, 'isEnum')) {
+            return null;
+        }
+
+        if (! $class->isEnum()) {
+            return null;
+        }
+
+        return TransformedType::create(
+            $class,
+            $name,
+            $this->resolveOptions($class)
+        );
+    }
+
+    private function resolveOptions(ReflectionClass $class): string
+    {
+        $enum = (new ReflectionEnum($class->getName()));
+    
+        $options = array_map(
+            fn ($enum) => "'{$enum}' = '{$enum}'",
+            array_keys($enum->getConstants())
+        );
+    
+        return implode(', ', $options);
+    }
+}

--- a/src/Transformers/SpatieEnumNativeTransformer.php
+++ b/src/Transformers/SpatieEnumNativeTransformer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Transformers;
+
+use ReflectionClass;
+use Spatie\Enum\Enum;
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
+
+class SpatieEnumNativeTransformer implements Transformer
+{
+    public function transform(ReflectionClass $class, string $name): ?TransformedType
+    {
+        if ($class->isSubclassOf(Enum::class) === false) {
+            return null;
+        }
+
+        return TransformedType::create(
+            $class,
+            $name,
+            $this->resolveOptions($class),
+            null,
+            false,
+            'enum'
+        );
+    }
+
+    private function resolveOptions(ReflectionClass $class): string
+    {
+        /** @var \Spatie\Enum\Enum $enum */
+        $enum = $class->getName();
+    
+        $options = array_map(
+            fn ($key, $value) => "'{$key}' = '{$value}'",
+            array_keys($enum::toArray()), $enum::toArray()
+        );
+    
+        return implode(', ', $options);
+    }
+}

--- a/src/Writers/ModuleWriter.php
+++ b/src/Writers/ModuleWriter.php
@@ -23,7 +23,7 @@ class ModuleWriter implements Writer
                 continue;
             }
 
-            $output .= "export type {$type->name} = {$type->transformed};".PHP_EOL;
+            $output .= "export {$type->toString()};".PHP_EOL;
         }
 
         return $output;

--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -19,7 +19,7 @@ class TypeDefinitionWriter implements Writer
         foreach ($namespaces as $namespace => $types) {
             asort($types);
 
-            $output .= "namespace {$namespace} {".PHP_EOL;
+            $output .= "declare namespace {$namespace} {".PHP_EOL;
 
             $output .= join(PHP_EOL, array_map(
                 fn (TransformedType $type) => "export {$type->toString()};",

--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -19,10 +19,10 @@ class TypeDefinitionWriter implements Writer
         foreach ($namespaces as $namespace => $types) {
             asort($types);
 
-            $output .= "declare namespace {$namespace} {".PHP_EOL;
+            $output .= "namespace {$namespace} {".PHP_EOL;
 
             $output .= join(PHP_EOL, array_map(
-                fn (TransformedType $type) => "export type {$type->name} = {$type->transformed};",
+                fn (TransformedType $type) => "export {$type->toString()};",
                 $types
             ));
 
@@ -31,7 +31,7 @@ class TypeDefinitionWriter implements Writer
         }
 
         $output .= join(PHP_EOL, array_map(
-            fn (TransformedType $type) => "export type {$type->name} = {$type->transformed};",
+            fn (TransformedType $type) => "export {$type->toString()};",
             $rootTypes
         ));
 

--- a/tests/Fakes/FakeTransformedType.php
+++ b/tests/Fakes/FakeTransformedType.php
@@ -9,7 +9,7 @@ use Spatie\TypeScriptTransformer\Structures\TransformedType;
 
 class FakeTransformedType extends TransformedType
 {
-    public static function create(ReflectionClass $class, string $name, string $transformed, ?MissingSymbolsCollection $missingSymbols = null, bool $inline = false): TransformedType
+    public static function create(ReflectionClass $class, string $name, string $transformed, ?MissingSymbolsCollection $missingSymbols = null, bool $inline = false, string $format = 'type'): TransformedType
     {
         throw new Exception("Fake type");
     }

--- a/tests/Transformers/EnumNativeTransformerTest.php
+++ b/tests/Transformers/EnumNativeTransformerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\Transformers;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Enum;
+use Spatie\TypeScriptTransformer\Transformers\EnumNativeTransformer;
+
+class EnumNativeTransformerTest extends TestCase
+{
+    private EnumNativeTransformer $transformer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Native enums not supported before PHP 8.1');
+        }
+
+        $this->transformer = new EnumNativeTransformer();
+    }
+
+    /** @test */
+    public function it_will_only_convert_enums()
+    {
+        $this->assertNotNull($this->transformer->transform(
+            new ReflectionClass(Enum::class),
+            'Enum',
+        ));
+
+        $this->assertNull($this->transformer->transform(
+            new ReflectionClass(DateTime::class),
+            'Enum',
+        ));
+    }
+
+    /** @test */
+    public function it_can_transform_an_enum()
+    {
+        $type = $this->transformer->transform(
+            new ReflectionClass(Enum::class),
+            'Enum'
+        );
+
+        $this->assertEquals("'JS' = 'JS', | 'PHP' = 'PHP'", $type->transformed);
+        $this->assertTrue($type->missingSymbols->isEmpty());
+        $this->assertFalse($type->isInline);
+    }
+}

--- a/tests/Transformers/SpatieEnumNativeTransformerTest.php
+++ b/tests/Transformers/SpatieEnumNativeTransformerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\Transformers;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\SpatieEnum;
+use Spatie\TypeScriptTransformer\Transformers\SpatieEnumNativeTransformer;
+
+class SpatieEnumNativeTransformerTest extends TestCase
+{
+    private SpatieEnumNativeTransformer $transformer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transformer = new SpatieEnumNativeTransformer();
+    }
+
+    /** @test */
+    public function it_will_only_convert_enums()
+    {
+        $this->assertNotNull($this->transformer->transform(
+            new ReflectionClass(SpatieEnum::class),
+            'State',
+        ));
+
+        $this->assertNull($this->transformer->transform(
+            new ReflectionClass(DateTime::class),
+            'State',
+        ));
+    }
+
+    /** @test */
+    public function it_can_transform_an_enum()
+    {
+        $type = $this->transformer->transform(
+            new ReflectionClass(SpatieEnum::class),
+            'FakeEnum'
+        );
+
+        $this->assertEquals("'draft' = 'Draft', 'published' = 'Published', 'archived' = 'Archived'", $type->transformed);
+        $this->assertTrue($type->missingSymbols->isEmpty());
+        $this->assertFalse($type->isInline);
+    }
+}


### PR DESCRIPTION
Right now, all generated types are Typescript types but it would be nice to transform PHP enums into Typescript enums. This PR allows developers to output enums but does not break existing behaviour.

As a developer you could use the following transformer to transform Spatie enums:
```php
<?php

namespace App\Support\TypeScript\Transformers;

use ReflectionClass;
use Spatie\Enum\Enum;
use Spatie\TypeScriptTransformer\Structures\TransformedType;
use Spatie\TypeScriptTransformer\Transformers\Transformer;

class SpatieEnumTransformer implements Transformer
{
    public function transform(ReflectionClass $class, string $name): ?TransformedType
    {
        if ($class->isSubclassOf(Enum::class) === false) {
            return null;
        }

        return TransformedType::create(
            $class,
            $name,
            $this->resolveOptions($class),
            null,
            false,
            'enum'
        );
    }

    private function resolveOptions(ReflectionClass $class): string
    {
        /** @var \Spatie\Enum\Enum $enum */
        $enum = $class->getName();

        $options = collect($enum::toArray())->mapWithKeys(function ($value, $key) {
            return [$key => "'{$key}' = '{$value}'"];
        })->toArray();

        return implode(', ', $options);
    }
}
```