### PR TITLE
Allow interfaces in default type replacements

### DIFF
--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -137,7 +137,7 @@ class TypeScriptTransformerConfig
         $replacements = [];
 
         foreach ($this->defaultTypeReplacements as $class => $replacement) {
-            if (! class_exists($class)) {
+            if (! class_exists($class) && ! interface_exists($class)) {
                 throw InvalidDefaultTypeReplacer::classDoesNotExist($class);
             }
 


### PR DESCRIPTION
For example, we use the `Carbon\CarbonInterface` often, but we cannot set a default replacement for it now.