### PR TITLE
Feature/multiple file output

### DIFF
--- a/docs/laravel/installation-and-setup.md
+++ b/docs/laravel/installation-and-setup.md
@@ -72,7 +72,7 @@ return [
      * The package will write the generated TypeScript to this file.
      */
 
-    'output_file' => resource_path('types/generated.d.ts'),
+    'output_destination' => resource_path('types/generated.d.ts'),
 
     /*
      * When the package is writing types to the output file, a writer is used to

--- a/src/Actions/FormatTypeScriptAction.php
+++ b/src/Actions/FormatTypeScriptAction.php
@@ -21,6 +21,12 @@ class FormatTypeScriptAction
             return;
         }
 
-        $formatter->format($this->config->getOutputFile());
+        $outputDestination = $this->config->getOutputDestination();
+
+        if ($this->config->getOutput()->writesMultipleFiles()) {
+            $outputDestination = is_file($outputDestination) ? dirname($outputDestination) : $outputDestination;
+        }
+
+        $formatter->format($outputDestination);
     }
 }

--- a/src/Actions/PersistTypesCollectionAction.php
+++ b/src/Actions/PersistTypesCollectionAction.php
@@ -16,8 +16,6 @@ class PersistTypesCollectionAction
 
     public function execute(TypesCollection $collection): void
     {
-        $this->ensureOutputFileExists();
-
         $writer = $this->config->getWriter();
 
         (new ReplaceSymbolsInCollectionAction())->execute(
@@ -25,16 +23,6 @@ class PersistTypesCollectionAction
             $writer->replacesSymbolsWithFullyQualifiedIdentifiers()
         );
 
-        file_put_contents(
-            $this->config->getOutputFile(),
-            $writer->format($collection)
-        );
-    }
-
-    protected function ensureOutputFileExists(): void
-    {
-        if (! file_exists(pathinfo($this->config->getOutputFile(), PATHINFO_DIRNAME))) {
-            mkdir(pathinfo($this->config->getOutputFile(), PATHINFO_DIRNAME), 0755, true);
-        }
+        $writer->format($collection);
     }
 }

--- a/src/Actions/ReplaceSymbolsInTypeAction.php
+++ b/src/Actions/ReplaceSymbolsInTypeAction.php
@@ -45,6 +45,7 @@ class ReplaceSymbolsInTypeAction
 
         if (! $found->isInline) {
             $type->replaceSymbol($missingSymbol, $found->getTypeScriptName($this->withFullyQualifiedNames));
+            $this->withFullyQualifiedNames || $type->addImport($missingSymbol);
 
             return $type;
         }

--- a/src/Output/MultipleFileOutput.php
+++ b/src/Output/MultipleFileOutput.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Output;
+
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+
+class MultipleFileOutput extends Output
+{
+    public function __construct(protected TypeScriptTransformerConfig $config)
+    {
+        $path = $config->getOutputDestination();
+        $this->path = is_dir($path) ? rtrim($path, '/') : pathinfo($path, PATHINFO_DIRNAME);
+        $this->output = [];
+
+    }
+
+    public function append(string $typeScript, string $classPath = null): void
+    {
+        $pathName = ltrim(str_replace('\\', '/', $classPath), '/');
+
+        $this->output[$pathName] = $typeScript;
+    }
+
+    public function writeOut($fileType): array
+    {
+        $this->clearPrevious($fileType);
+
+        foreach ($this->output as $path => $contents) {
+            if ($contents === '') {
+                continue;
+            }
+
+            $path = "$this->path/$path.{$fileType}";
+
+            $this->ensureFilesExist($path);
+            file_put_contents(
+                $path,
+                $contents
+            );
+        }
+
+        return array_keys($this->output);
+    }
+
+    public function writesMultipleFiles(): bool
+    {
+        return true;
+    }
+
+    protected function clearPrevious(string $fileType): void
+    {
+        // In case there are previously defined types that are no longer needed
+        if (is_dir($this->path)) {
+            // Delete the namespaced folder as that's most likely to contain only generated files
+            // as apposed to manually defined types not generated from PHP classes
+            $baseNamespaces = array_map(
+                 fn (string $relativePath) => preg_replace(
+                    "/.{$fileType}$/",
+                    '',
+                    explode('/', $relativePath)[0]
+                ),
+                array_keys($this->output)
+            );
+            $uniqueNamespaces = array_keys(
+                array_flip($baseNamespaces)
+            );
+
+            // Clear out each of the folders
+            // PHP can't delete a folder that's not empty
+            foreach ($uniqueNamespaces as $namespace) {
+                $fullPath = "{$this->path}/{$namespace}";
+                if (!is_dir($fullPath)) {
+                    continue;
+                }
+
+                $directoryIterator = new \RecursiveDirectoryIterator(
+                    $fullPath,
+                    \FilesystemIterator::SKIP_DOTS
+                );
+                $files = new \RecursiveIteratorIterator(
+                    $directoryIterator,
+                    \RecursiveIteratorIterator::CHILD_FIRST
+                );
+
+                /** @var \SplFileInfo $file */
+                foreach ($files as $file) {
+                    $file->isDir() && rmdir($file->getPathname());
+                    $file->isFile() && unlink($file->getPathname());
+                }
+
+                rmdir($fullPath);
+            }
+        }
+
+    }
+
+}

--- a/src/Output/Output.php
+++ b/src/Output/Output.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Output;
+
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+
+abstract class Output
+{
+    protected string|array $output;
+    protected TypeScriptTransformerConfig $config;
+    protected string $path;
+
+    abstract public function __construct(TypeScriptTransformerConfig $config);
+
+    abstract public function append(string $typeScript, string $classPath = null): void;
+
+    abstract public function writeOut(string $fileType): array;
+
+    abstract public function writesMultipleFiles(): bool;
+
+    protected function ensureFilesExist(string $fullPath): void
+    {
+        if (! file_exists(pathinfo($fullPath, PATHINFO_DIRNAME))) {
+            mkdir(pathinfo($fullPath, PATHINFO_DIRNAME), 0755, true);
+        }
+    }
+}

--- a/src/Output/SingleFileOutput.php
+++ b/src/Output/SingleFileOutput.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Output;
+
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+
+class SingleFileOutput extends Output
+{
+
+    public function __construct(protected TypeScriptTransformerConfig $config)
+    {
+        $this->output = '';
+        $this->path = $config->getOutputDestination();
+    }
+
+    public function append(string $typeScript, string $classPath = null): void
+    {
+        $this->output .= $typeScript;
+    }
+
+    public function writeOut(string $fileType): array
+    {
+        $fileType = ltrim($fileType, '.');
+        $path = preg_replace("/.{$fileType}$/", '', $this->path);
+        $path .= ".{$fileType}";
+        $this->ensureFilesExist($path);
+
+        file_put_contents(
+            $path,
+            $this->output
+        );
+
+        // We only write to one path
+        return [$path];
+    }
+
+    public function writesMultipleFiles(): bool
+    {
+        return false;
+    }
+}

--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -21,7 +21,7 @@ class TypeScriptTransformerConfig
 
     private array $collectors = [DefaultCollector::class];
 
-    private string $outputFile = 'types.d.ts';
+    private string $outputDestination = 'types.d.ts';
 
     private array $defaultTypeReplacements = [];
 
@@ -73,9 +73,9 @@ class TypeScriptTransformerConfig
         return $this;
     }
 
-    public function outputFile(string $defaultFile): self
+    public function outputDestination(string $defaultDestination): self
     {
-        $this->outputFile = $defaultFile;
+        $this->outputDestination = $defaultDestination;
 
         return $this;
     }
@@ -132,7 +132,7 @@ class TypeScriptTransformerConfig
         return new $this->output($this);
     }
 
-    public function getOutputFile(): string
+    public function getOutputDestination(): string
     {
         return $this->outputDestination;
     }

--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -7,6 +7,8 @@ use phpDocumentor\Reflection\TypeResolver;
 use Spatie\TypeScriptTransformer\Collectors\DefaultCollector;
 use Spatie\TypeScriptTransformer\Exceptions\InvalidDefaultTypeReplacer;
 use Spatie\TypeScriptTransformer\Formatters\Formatter;
+use Spatie\TypeScriptTransformer\Output\Output;
+use Spatie\TypeScriptTransformer\Output\SingleFileOutput;
 use Spatie\TypeScriptTransformer\Transformers\Transformer;
 use Spatie\TypeScriptTransformer\Writers\TypeDefinitionWriter;
 use Spatie\TypeScriptTransformer\Writers\Writer;
@@ -24,6 +26,8 @@ class TypeScriptTransformerConfig
     private array $defaultTypeReplacements = [];
 
     private string $writer = TypeDefinitionWriter::class;
+
+    private string $output = SingleFileOutput::class;
 
     private ?string $formatter = null;
 
@@ -58,6 +62,13 @@ class TypeScriptTransformerConfig
     public function writer(string $writer): self
     {
         $this->writer = $writer;
+
+        return $this;
+    }
+
+    public function output(string $output): self
+    {
+        $this->output = $output;
 
         return $this;
     }
@@ -113,12 +124,17 @@ class TypeScriptTransformerConfig
 
     public function getWriter(): Writer
     {
-        return new $this->writer;
+        return new $this->writer($this);
+    }
+
+    public function getOutput(): Output
+    {
+        return new $this->output($this);
     }
 
     public function getOutputFile(): string
     {
-        return $this->outputFile;
+        return $this->outputDestination;
     }
 
     /** @return \Spatie\TypeScriptTransformer\Collectors\Collector[] */

--- a/src/Writers/ModuleWriter.php
+++ b/src/Writers/ModuleWriter.php
@@ -4,10 +4,14 @@ namespace Spatie\TypeScriptTransformer\Writers;
 
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class ModuleWriter implements Writer
 {
-    public function format(TypesCollection $collection): string
+    public function __construct(protected TypeScriptTransformerConfig $config)
+    {}
+
+    public function format(TypesCollection $collection): void
     {
         $output = '';
 
@@ -18,7 +22,9 @@ class ModuleWriter implements Writer
             return strcmp($a->name, $b->name);
         });
 
-        foreach ($iterator as $type) {
+        $output = $this->config->getOutput();
+
+        foreach ($iterator as $namespace => $type) {
             if ($type->isInline) {
                 continue;
             }

--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -40,7 +40,9 @@ class TypeDefinitionWriter implements Writer
             $rootTypes
         ));
 
-        return $output;
+        $output->append($typescript, str_replace('.', '\\', 'Root'));
+
+        $output->writeOut('d.ts');
     }
 
     public function replacesSymbolsWithFullyQualifiedIdentifiers(): bool

--- a/src/Writers/Writer.php
+++ b/src/Writers/Writer.php
@@ -3,10 +3,13 @@
 namespace Spatie\TypeScriptTransformer\Writers;
 
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 interface Writer
 {
-    public function format(TypesCollection $collection): string;
+    public function __construct(TypeScriptTransformerConfig $config);
+
+    public function format(TypesCollection $collection): void;
 
     public function replacesSymbolsWithFullyQualifiedIdentifiers(): bool;
 }

--- a/tests/Actions/FormatTypeScriptActionTest.php
+++ b/tests/Actions/FormatTypeScriptActionTest.php
@@ -39,7 +39,7 @@ class FormatTypeScriptActionTest extends TestCase
         $action = new FormatTypeScriptAction(
             TypeScriptTransformerConfig::create()
                 ->formatter($formatter::class)
-                ->outputFile($this->outputFile)
+                ->outputDestination($this->outputFile)
         );
 
         file_put_contents(
@@ -56,7 +56,7 @@ class FormatTypeScriptActionTest extends TestCase
     public function it_can_disable_formatting()
     {
         $action = new FormatTypeScriptAction(
-            TypeScriptTransformerConfig::create()->outputFile($this->outputFile)
+            TypeScriptTransformerConfig::create()->outputDestination($this->outputFile)
         );
 
         file_put_contents(

--- a/tests/Actions/PersistTypesCollectionActionTest.php
+++ b/tests/Actions/PersistTypesCollectionActionTest.php
@@ -29,7 +29,7 @@ class PersistTypesCollectionActionTest extends TestCase
             TypeScriptTransformerConfig::create()
                 ->autoDiscoverTypes(__DIR__ . '/../FakeClasses')
                 ->transformers([MyclabsEnumTransformer::class])
-                ->outputFile($this->temporaryDirectory->path('types.d.ts'))
+                ->outputDestination($this->temporaryDirectory->path('types.d.ts'))
         );
     }
 

--- a/tests/Actions/ResolveTypesCollectionActionTest.php
+++ b/tests/Actions/ResolveTypesCollectionActionTest.php
@@ -37,7 +37,7 @@ class ResolveTypesCollectionActionTest extends TestCase
                 ->autoDiscoverTypes(__DIR__ . '/../FakeClasses/Enum')
                 ->transformers([MyclabsEnumTransformer::class])
                 ->collectors([DefaultCollector::class])
-                ->outputFile('types.d.ts')
+                ->outputDestination('types.d.ts')
         );
     }
 
@@ -107,7 +107,7 @@ class ResolveTypesCollectionActionTest extends TestCase
                 )
                 ->transformers([MyclabsEnumTransformer::class, DtoTransformer::class])
                 ->collectors([DefaultCollector::class])
-                ->outputFile('types.d.ts')
+                ->outputDestination('types.d.ts')
         );
 
         $types = $this->action->execute();
@@ -134,7 +134,7 @@ class ResolveTypesCollectionActionTest extends TestCase
             TypeScriptTransformerConfig::create()
                 ->autoDiscoverTypes(__DIR__ . '/../FakeClasses/Enum')
                 ->collectors([FakeTypeScriptCollector::class])
-                ->outputFile('types.d.ts')
+                ->outputDestination('types.d.ts')
         );
 
         $types = $this->action->execute();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -41,7 +41,7 @@ class IntegrationTest extends TestCase
 
         $transformer = new TypeScriptTransformer(
             $this->getTransformerConfig()
-                ->outputFile($temporaryDirectory->path('types.d.ts'))
+                ->outputDestination($temporaryDirectory->path('types.d.ts'))
         );
 
         $transformer->transform();
@@ -59,7 +59,7 @@ class IntegrationTest extends TestCase
         $transformer = new TypeScriptTransformer(
             $this->getTransformerConfig()
                 ->writer(ModuleWriter::class)
-                ->outputFile($temporaryDirectory->path('types.ts'))
+                ->outputDestination($temporaryDirectory->path('types.ts'))
         );
 
         $transformer->transform();


### PR DESCRIPTION
This code allows for outputting the types to multiple files and folders.
The reason I believe this would be useful to others besides myself is:
- As soon as you have an entity with the same name across two namespaces it's no longer possible to use your package as it is
- In both Typescript and PHP the default way we write our code is to keep classes and types in separate files (excepting of course the `.d.ts` reference files.

If you think this feature has legs, I will happily write the tests and update the docs.
I changed the name of one of the config params and added a requirement of passing an instance of `TypeScriptTransformerConfig` to `Writer::__construct()` - so this will more than likely need to be a major or minor version jump.

* Extract the string collection and text output functionality to a separate class
  - This will allow us to use different, configurable strategies of how to output to files
  - Only add the default `SingleFileOutput` for now
    * That is the current behaviour of the library
* Add an `Output` child class that separates output into multiple files
  - The reason this could be useful is if you have similarly names entities across namespaces
  - Having a separate file for each type is also more typical when building an application in Typescript or PHP
* Change `output_file` to `output_destination`
  - It could refer to a directory or a file with `MultipleFileOutput`
* Allow for passing a directory through to the `path` of the formatter
  - It could refer to a directory with many files if we are using `MultipleFileOutput`
* Add support for handling `import Foo from 'bar';` in typescript
  - Because we could be exporting to many files, we will need to track the other PHP classes/TS types that are referenced