### PR TITLE
Allow whitespace in type definitions

### DIFF
--- a/src/TypeReflectors/MethodParameterTypeReflector.php
+++ b/src/TypeReflectors/MethodParameterTypeReflector.php
@@ -26,7 +26,7 @@ class MethodParameterTypeReflector extends TypeReflector
 
     protected function docblockRegex(): string
     {
-        return "/@param ((?:(?:[\\w?|\\\\<>,])+(?:\\[])?)+) \\\${$this->reflection->getName()}/";
+        return "/@param ((?:\\s?[\\w?|\\\\<>,]+(?:\\[])?)+) \\\${$this->reflection->getName()}/";
     }
 
     protected function getReflectionType(): ?ReflectionType

--- a/src/TypeReflectors/MethodReturnTypeReflector.php
+++ b/src/TypeReflectors/MethodReturnTypeReflector.php
@@ -26,7 +26,7 @@ class MethodReturnTypeReflector extends TypeReflector
 
     protected function docblockRegex(): string
     {
-        return '/@return ((?:(?:[\w?|\\\\<>,])+(?:\[])?)+)/';
+        return '/@return ((?:\s?[\w?|\\\\<>,]+(?:\[])?)+)/';
     }
 
     protected function getReflectionType(): ?ReflectionType

--- a/src/TypeReflectors/PropertyTypeReflector.php
+++ b/src/TypeReflectors/PropertyTypeReflector.php
@@ -26,7 +26,7 @@ class PropertyTypeReflector extends TypeReflector
 
     protected function docblockRegex(): string
     {
-        return '/@var ((?:(?:[\w?|\\\\<>,])+(?:\[])?)+)/';
+        return '/@var ((?:\s?[\\w?|\\\\<>,]+(?:\[])?)+)/';
     }
 
     protected function getReflectionType(): ?ReflectionType


### PR DESCRIPTION
When you have a type definition that contains any whitespace, such as `array<int | string>` it's not matched properly and results in errors. This fix includes a small change to the regexes so that whitespace between tokens are correctly matched again.