### PR TITLE
feat: support `Optional` attribute

### DIFF
--- a/src/Actions/TranspileTypeToTypeScriptAction.php
+++ b/src/Actions/TranspileTypeToTypeScriptAction.php
@@ -30,11 +30,15 @@ class TranspileTypeToTypeScriptAction
 
     private ?string $currentClass;
 
+    private bool $nullablesAreOptional;
+
     public function __construct(
         MissingSymbolsCollection $missingSymbolsCollection,
-        ?string $currentClass = null
+        bool $nullablesAreOptional = false,
+        ?string $currentClass = null,
     ) {
         $this->missingSymbolsCollection = $missingSymbolsCollection;
+        $this->nullablesAreOptional = $nullablesAreOptional;
         $this->currentClass = $currentClass;
     }
 
@@ -80,6 +84,10 @@ class TranspileTypeToTypeScriptAction
 
     private function resolveNullableType(Nullable $nullable): string
     {
+        if ($this->nullablesAreOptional) {
+            return $this->execute($nullable->getActualType());
+        }
+
         return "{$this->execute($nullable->getActualType())} | null";
     }
 

--- a/src/Attributes/Optional.php
+++ b/src/Attributes/Optional.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Attributes;
+
+use Attribute;
+
+#[Attribute]
+class Optional
+{
+}

--- a/src/Collectors/DefaultCollector.php
+++ b/src/Collectors/DefaultCollector.php
@@ -37,10 +37,12 @@ class DefaultCollector extends Collector
     {
         $missingSymbols = new MissingSymbolsCollection();
         $name = $reflector->getName();
+        $nullablesAreOptional = $this->config->shouldConsiderNullAsOptional();
 
         $transpiler = new TranspileTypeToTypeScriptAction(
             $missingSymbols,
-            $name
+            $nullablesAreOptional,
+            $name,
         );
 
         return TransformedType::create(

--- a/src/Transformers/TransformsTypes.php
+++ b/src/Transformers/TransformsTypes.php
@@ -7,6 +7,7 @@ use ReflectionMethod;
 use ReflectionParameter;
 use ReflectionProperty;
 use Spatie\TypeScriptTransformer\Actions\TranspileTypeToTypeScriptAction;
+use Spatie\TypeScriptTransformer\Attributes\Optional;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\TypeProcessors\TypeProcessor;
 use Spatie\TypeScriptTransformer\TypeReflectors\TypeReflector;
@@ -16,6 +17,7 @@ trait TransformsTypes
     protected function reflectionToTypeScript(
         ReflectionMethod | ReflectionProperty | ReflectionParameter $reflection,
         MissingSymbolsCollection $missingSymbolsCollection,
+        bool $nullablesAreOptional = false,
         TypeProcessor ...$typeProcessors
     ): ?string {
         $type = $this->reflectionToType(
@@ -31,6 +33,7 @@ trait TransformsTypes
         return $this->typeToTypeScript(
             $type,
             $missingSymbolsCollection,
+            $nullablesAreOptional,
             $reflection->getDeclaringClass()?->getName()
         );
     }
@@ -60,11 +63,13 @@ trait TransformsTypes
     protected function typeToTypeScript(
         Type $type,
         MissingSymbolsCollection $missingSymbolsCollection,
+        bool $nullablesAreOptional = false,
         ?string $currentClass = null,
     ): string {
         $transpiler = new TranspileTypeToTypeScriptAction(
             $missingSymbolsCollection,
-            $currentClass
+            $nullablesAreOptional,
+            $currentClass,
         );
 
         return $transpiler->execute($type);

--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -29,6 +29,8 @@ class TypeScriptTransformerConfig
 
     private bool $transformToNativeEnums = false;
 
+    private bool $nullToOptional = false;
+
     public static function create(): self
     {
         return new self();
@@ -86,6 +88,13 @@ class TypeScriptTransformerConfig
     public function transformToNativeEnums(bool $transformToNativeEnums = true): self
     {
         $this->transformToNativeEnums = $transformToNativeEnums;
+
+        return $this;
+    }
+
+    public function nullToOptional(bool $nullToOptional = false): self
+    {
+        $this->nullToOptional = $nullToOptional;
 
         return $this;
     }
@@ -161,5 +170,10 @@ class TypeScriptTransformerConfig
     public function shouldTransformToNativeEnums(): bool
     {
         return $this->transformToNativeEnums;
+    }
+
+    public function shouldConsiderNullAsOptional(): bool
+    {
+        return $this->nullToOptional;
     }
 }

--- a/tests/Actions/TranspileTypeToTypeScriptActionTest.php
+++ b/tests/Actions/TranspileTypeToTypeScriptActionTest.php
@@ -3,8 +3,10 @@
 namespace Spatie\TypeScriptTransformer\Tests\Actions;
 
 use phpDocumentor\Reflection\TypeResolver;
+use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Self_;
 use phpDocumentor\Reflection\Types\Static_;
+use phpDocumentor\Reflection\Types\String_;
 use phpDocumentor\Reflection\Types\This;
 use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\MatchesSnapshots;
@@ -34,6 +36,7 @@ class TranspileTypeToTypeScriptActionTest extends TestCase
 
         $this->action = new TranspileTypeToTypeScriptAction(
             $this->missingSymbols,
+            false,
             'fake_class'
         );
     }
@@ -138,5 +141,21 @@ class TranspileTypeToTypeScriptActionTest extends TestCase
         $this->assertMatchesSnapshot($transformed);
         $this->assertContains(RegularEnum::class, $this->missingSymbols->all());
         $this->assertContains('fake_class', $this->missingSymbols->all());
+    }
+
+    /** @test */
+    public function it_does_not_add_nullable_unions_to_optional_properties()
+    {
+        $action = new TranspileTypeToTypeScriptAction(
+            $this->missingSymbols,
+            true
+        );
+
+        $transformed = $action->execute(StructType::fromArray([
+            'a_string' => 'string',
+            'a_nullable_string' => '?string',
+        ]));
+
+        $this->assertEquals('{a_string:string;a_nullable_string:string;}', $transformed);
     }
 }

--- a/tests/Transformers/DtoTransformerTest.php
+++ b/tests/Transformers/DtoTransformerTest.php
@@ -12,6 +12,7 @@ use ReflectionParameter;
 use ReflectionProperty;
 use Spatie\Snapshots\MatchesSnapshots;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
+use Spatie\TypeScriptTransformer\Attributes\Optional;
 use Spatie\TypeScriptTransformer\Attributes\TypeScriptType;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\Tests\FakeClasses\Enum\RegularEnum;
@@ -113,6 +114,38 @@ class DtoTransformerTest extends TestCase
         };
 
         $type = $this->transformer->transform(
+            new ReflectionClass($class),
+            'Typed'
+        );
+
+        $this->assertMatchesSnapshot($type->transformed);
+    }
+
+    /** @test */
+    public function it_transforms_nullable_properties_to_optional_ones_when_using_optional_attribute()
+    {
+        $class = new class {
+            #[Optional]
+            public ?string $string;
+        };
+
+        $type = $this->transformer->transform(
+            new ReflectionClass($class),
+            'Typed'
+        );
+
+        $this->assertMatchesSnapshot($type->transformed);
+    }
+
+    /** @test */
+    public function it_transforms_nullable_properties_to_optional_ones_according_to_config()
+    {
+        $class = new class {
+            public ?string $string;
+        };
+
+        $config = TypeScriptTransformerConfig::create()->nullToOptional(true);
+        $type = (new DtoTransformer($config))->transform(
             new ReflectionClass($class),
             'Typed'
         );

--- a/tests/Transformers/__snapshots__/DtoTransformerTest__it_transforms_nullable_properties_to_optional_ones_according_to_config__1.txt
+++ b/tests/Transformers/__snapshots__/DtoTransformerTest__it_transforms_nullable_properties_to_optional_ones_according_to_config__1.txt
@@ -1,0 +1,3 @@
+{
+string?: string;
+}

--- a/tests/Transformers/__snapshots__/DtoTransformerTest__it_transforms_nullable_properties_to_optional_ones_when_using_optional_attribute__1.txt
+++ b/tests/Transformers/__snapshots__/DtoTransformerTest__it_transforms_nullable_properties_to_optional_ones_when_using_optional_attribute__1.txt
@@ -1,0 +1,3 @@
+{
+string?: string;
+}


### PR DESCRIPTION
This PR implements a new `Optional` attribute that makes the property it is associated to as, well, optional. 

When a property is `Optional`:
- Its generated TypeScript type will not add a union `null` type
- It will be optional in its TypeScript interface

Additionally, I added a new `nullToOptional` parameter to the configuration that allows transforming all `null` properties to optional ones. By default, it is `false` for obvious backward compatibility reasons.

An example using the `DtoTransformer`:

```php
class UserDto {
  #[Optional]
  public ?id $id;
  public string $first_name;
}
```

```ts
interface UserDto {
  id?: number;           // instead of `id: number | null`
  first_name: string;
}
```

In the above example, if using `nullToOptional`, the `Optional` attribute is not necessary to generate the exact same interface.

Closes https://github.com/spatie/typescript-transformer/issues/23
Related comment: https://github.com/spatie/typescript-transformer/issues/23#issuecomment-1113404213
