### PR TITLE
Transform interfaces

### DIFF
--- a/src/Actions/TranspileTypeToTypeScriptAction.php
+++ b/src/Actions/TranspileTypeToTypeScriptAction.php
@@ -54,7 +54,7 @@ class TranspileTypeToTypeScriptAction
             $type instanceof Self_, $type instanceof Static_, $type instanceof This => $this->resolveSelfReferenceType(),
             $type instanceof Scalar => 'string|number|boolean',
             $type instanceof Mixed_ => 'any',
-            $type instanceof Void_ => 'never',
+            $type instanceof Void_ => 'void',
             default => throw new Exception("Could not transform type: {$type}")
         };
     }

--- a/src/Structures/TransformedType.php
+++ b/src/Structures/TransformedType.php
@@ -18,15 +18,18 @@ class TransformedType
 
     public string $keyword;
 
+    public bool $trailingSemicolon;
+
     public static function create(
         ReflectionClass $class,
         string $name,
         string $transformed,
         ?MissingSymbolsCollection $missingSymbols = null,
         bool $inline = false,
-        string $keyword = 'type'
+        string $keyword = 'type',
+        bool $trailingSemicolon = true,
     ): self {
-        return new self($class, $name, $transformed, $missingSymbols ?? new MissingSymbolsCollection(), $inline, $keyword);
+        return new self($class, $name, $transformed, $missingSymbols ?? new MissingSymbolsCollection(), $inline, $keyword, $trailingSemicolon);
     }
 
     public static function createInline(
@@ -43,7 +46,8 @@ class TransformedType
         string $transformed,
         MissingSymbolsCollection $missingSymbols,
         bool $isInline,
-        string $keyword = 'type'
+        string $keyword = 'type',
+        bool $trailingSemicolon = true,
     ) {
         $this->reflection = $class;
         $this->name = $name;
@@ -51,6 +55,7 @@ class TransformedType
         $this->missingSymbols = $missingSymbols;
         $this->isInline = $isInline;
         $this->keyword = $keyword;
+        $this->trailingSemicolon = $trailingSemicolon;
     }
 
     public function getNamespaceSegments(): array
@@ -95,9 +100,12 @@ class TransformedType
 
     public function toString(): string
     {
-        return match ($this->keyword) {
+        $output = match ($this->keyword) {
             'enum' => "enum {$this->name} { {$this->transformed} }",
+            'interface' => "interface {$this->name} {$this->transformed}",
             default => "type {$this->name} = {$this->transformed}",
         };
+
+        return $output . ($this->trailingSemicolon ? ';' : '');
     }
 }

--- a/src/Transformers/InterfaceTransformer.php
+++ b/src/Transformers/InterfaceTransformer.php
@@ -11,6 +11,10 @@ class InterfaceTransformer extends DtoTransformer implements Transformer
 {
     public function transform(ReflectionClass $class, string $name): ?TransformedType
     {
+        if (! $class->isInterface()) {
+            return null;
+        }
+
         $transformedType = parent::transform($class, $name);
         $transformedType->keyword = 'interface';
         $transformedType->trailingSemicolon = false;
@@ -46,7 +50,7 @@ class InterfaceTransformer extends DtoTransformer implements Transformer
                 );
 
                 $returnType = 'any';
-                if ($method->getReturnType() !== null) {
+                if ($method->hasReturnType()) {
                     $returnType = $this->reflectionToTypeScript(
                         $method,
                         $missingSymbols,

--- a/src/Transformers/InterfaceTransformer.php
+++ b/src/Transformers/InterfaceTransformer.php
@@ -5,9 +5,19 @@ namespace Spatie\TypeScriptTransformer\Transformers;
 use ReflectionClass;
 use ReflectionMethod;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
 
 class InterfaceTransformer extends DtoTransformer implements Transformer
 {
+    public function transform(ReflectionClass $class, string $name): ?TransformedType
+    {
+        $transformedType = parent::transform($class, $name);
+        $transformedType->keyword = 'interface';
+        $transformedType->trailingSemicolon = false;
+
+        return $transformedType;
+    }
+
     protected function transformMethods(
         ReflectionClass $class,
         MissingSymbolsCollection $missingSymbols

--- a/src/Transformers/InterfaceTransformer.php
+++ b/src/Transformers/InterfaceTransformer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Transformers;
+
+use ReflectionClass;
+use ReflectionMethod;
+use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
+
+class InterfaceTransformer extends DtoTransformer implements Transformer
+{
+    protected function transformMethods(
+        ReflectionClass $class,
+        MissingSymbolsCollection $missingSymbols
+    ): string {
+        return array_reduce(
+            $class->getMethods(ReflectionMethod::IS_PUBLIC),
+            function (string $carry, ReflectionMethod $method) use ($missingSymbols) {
+
+                $transformedParameters = \array_reduce(
+                    $method->getParameters(),
+                    function (string $parameterCarry, \ReflectionParameter $parameter) use ($missingSymbols) {
+                        $type = $this->reflectionToTypeScript(
+                            $parameter,
+                            $missingSymbols,
+                            ...$this->typeProcessors()
+                        );
+
+                        $output = '';
+                        if ($parameterCarry !== '') {
+                            $output .= ', ';
+                        }
+
+                        return "{$parameterCarry}{$output}{$parameter->getName()}: {$type}";
+                    },
+                    ''
+                );
+
+                $returnType = 'any';
+                if ($method->getReturnType() !== null) {
+                    $returnType = $this->reflectionToTypeScript(
+                        $method,
+                        $missingSymbols,
+                        ...$this->typeProcessors()
+                    );
+                }
+
+                return "{$carry}{$method->getName()}({$transformedParameters}): {$returnType};" . PHP_EOL;
+            },
+            ''
+        );
+    }
+
+    protected function transformProperties(
+        ReflectionClass $class,
+        MissingSymbolsCollection $missingSymbols
+    ): string {
+        return '';
+    }
+}

--- a/src/Writers/ModuleWriter.php
+++ b/src/Writers/ModuleWriter.php
@@ -23,7 +23,7 @@ class ModuleWriter implements Writer
                 continue;
             }
 
-            $output .= "export {$type->toString()};".PHP_EOL;
+            $output .= "export {$type->toString()}".PHP_EOL;
         }
 
         return $output;

--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -22,7 +22,7 @@ class TypeDefinitionWriter implements Writer
             $output .= "declare namespace {$namespace} {".PHP_EOL;
 
             $output .= join(PHP_EOL, array_map(
-                fn (TransformedType $type) => "export {$type->toString()};",
+                fn (TransformedType $type) => "export {$type->toString()}",
                 $types
             ));
 
@@ -31,7 +31,7 @@ class TypeDefinitionWriter implements Writer
         }
 
         $output .= join(PHP_EOL, array_map(
-            fn (TransformedType $type) => "export {$type->toString()};",
+            fn (TransformedType $type) => "export {$type->toString()}",
             $rootTypes
         ));
 

--- a/tests/Fakes/FakeInterface.php
+++ b/tests/Fakes/FakeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\Fakes;
+
+interface FakeInterface
+{
+    public function testFunction(string $input, array $output): int;
+
+    function anotherTestFunction(): bool;
+}

--- a/tests/Fakes/FakeTransformedType.php
+++ b/tests/Fakes/FakeTransformedType.php
@@ -9,7 +9,7 @@ use Spatie\TypeScriptTransformer\Structures\TransformedType;
 
 class FakeTransformedType extends TransformedType
 {
-    public static function create(ReflectionClass $class, string $name, string $transformed, ?MissingSymbolsCollection $missingSymbols = null, bool $inline = false, string $keyword = 'type'): TransformedType
+    public static function create(ReflectionClass $class, string $name, string $transformed, ?MissingSymbolsCollection $missingSymbols = null, bool $inline = false, string $keyword = 'type', bool $trailingSemicolon = true): TransformedType
     {
         throw new Exception("Fake type");
     }

--- a/tests/Transformers/InterfaceTransformerTest.php
+++ b/tests/Transformers/InterfaceTransformerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\Transformers;
+
+use DateTime;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Spatie\Snapshots\MatchesSnapshots;
+use Spatie\TypeScriptTransformer\Tests\Fakes\FakeInterface;
+use Spatie\TypeScriptTransformer\Transformers\InterfaceTransformer;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+
+class InterfaceTransformerTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    /** @test */
+    public function it_will_only_convert_interfaces(): void
+    {
+        $transformer = new InterfaceTransformer(
+            TypeScriptTransformerConfig::create()
+        );
+
+        $this->assertNotNull($transformer->transform(
+            new ReflectionClass(DateTimeInterface::class),
+            'State',
+        ));
+
+        $this->assertNull($transformer->transform(
+            new ReflectionClass(DateTime::class),
+            'State',
+        ));
+    }
+
+    /** @test */
+    public function it_will_replace_methods(): void
+    {
+        $transformer = new InterfaceTransformer(
+            TypeScriptTransformerConfig::create()
+        );
+
+        $type = $transformer->transform(
+            new ReflectionClass(FakeInterface::class),
+            'State',
+        );
+
+        $this->assertMatchesTextSnapshot($type->transformed);
+    }
+}

--- a/tests/Transformers/__snapshots__/InterfaceTransformerTest__it_will_replace_methods__1.txt
+++ b/tests/Transformers/__snapshots__/InterfaceTransformerTest__it_will_replace_methods__1.txt
@@ -1,0 +1,4 @@
+{
+testFunction(input: string, output: Array<any>): number;
+anotherTestFunction(): boolean;
+}


### PR DESCRIPTION
This PR adds an `InterfaceTransformer` that allows transforming PHP interfaces to TypeScript interfaces.

```php
// PHP
interface FakeInterface
{
    public function testFunction(string $input, array $output): int;
    function anotherTestFunction(): bool;
}
```
```ts
// TypeScript
export interface FakeInterface {
    testFunction(input: string, output: Array<any>): number;
    anotherTestFunction(): boolean;
}
```