### PR TITLE
fix: inverse key and value for native enums

### DIFF
--- a/src/Transformers/SpatieEnumTransformer.php
+++ b/src/Transformers/SpatieEnumTransformer.php
@@ -30,7 +30,7 @@ class SpatieEnumTransformer implements Transformer
         $enum = $class->getName();
 
         $options = array_map(
-            fn ($key, $value) => "'{value}' = '{key}'",
+            fn ($key, $value) => "'{$value}' = '{$key}'",
             array_keys($enum::toArray()),
             $enum::toArray()
         );

--- a/src/Transformers/SpatieEnumTransformer.php
+++ b/src/Transformers/SpatieEnumTransformer.php
@@ -30,7 +30,7 @@ class SpatieEnumTransformer implements Transformer
         $enum = $class->getName();
 
         $options = array_map(
-            fn ($key, $value) => "'{$key}' = '{$value}'",
+            fn ($key, $value) => "'{value}' = '{key}'",
             array_keys($enum::toArray()),
             $enum::toArray()
         );

--- a/tests/Transformers/SpatieEnumTransformerTest.php
+++ b/tests/Transformers/SpatieEnumTransformerTest.php
@@ -59,7 +59,7 @@ class SpatieEnumTransformerTest extends TestCase
             'FakeEnum'
         );
 
-        $this->assertEquals("'draft' = 'Draft', 'published' = 'Published', 'archived' = 'Archived'", $type->transformed);
+        $this->assertEquals("'Draft' = 'draft', 'Published' = 'published', 'Archived' = 'archived'", $type->transformed);
         $this->assertTrue($type->missingSymbols->isEmpty());
         $this->assertFalse($type->isInline);
         $this->assertEquals('enum', $type->keyword);


### PR DESCRIPTION
Currently, if you use the native enum functionality with Spatie enums and custom values/labels it outputs the keys and values in the inverse format from my point of view. The current test case is already the best example:
https://github.com/spatie/typescript-transformer/blob/be7018fbb0276789ec391ce32af829d487b92393/tests/FakeClasses/SpatieEnum.php#L7-L23

will be transformed into:
https://github.com/spatie/typescript-transformer/blob/be7018fbb0276789ec391ce32af829d487b92393/tests/Transformers/SpatieEnumTransformerTest.php#L62

However, Typescript Enums actually work the other way around:
https://www.typescriptlang.org/docs/handbook/enums.html#string-enums

This is caused by these lines which intuitively look correct but are actually wrong:
https://github.com/spatie/typescript-transformer/blob/be7018fbb0276789ec391ce32af829d487b92393/src/Transformers/SpatieEnumTransformer.php#L32-L35

Though, checking the Spatie enum's `toArray` implementation the value is actually the key.
```php
$array[$definition->value] = $definition->label; 
```
(https://github.com/spatie/enum/blob/f1a0f464ba909491a53e60a955ce84ad7cd93a2c/src/Enum.php#L61-L63)