### PR TITLE
fix: Support `Collection` with `array-key` key type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "nikic/php-parser": "^4.13",
-        "phpdocumentor/type-resolver": "^1.5",
+        "phpdocumentor/type-resolver": "^1.5.1",
         "symfony/process": "^5.2|^6.0"
     },
     "require-dev": {

--- a/src/TypeReflectors/MethodParameterTypeReflector.php
+++ b/src/TypeReflectors/MethodParameterTypeReflector.php
@@ -24,7 +24,7 @@ class MethodParameterTypeReflector extends TypeReflector
 
     protected function docblockRegex(): string
     {
-        return "/@param ((?:\\s?[\\w?|\\\\<>,]+(?:\\[])?)+) \\\${$this->reflection->getName()}/";
+        return "/@param ((?:\\s?[\\w?|\\\\<>,-]+(?:\\[])?)+) \\\${$this->reflection->getName()}/";
     }
 
     protected function getReflectionType(): ?ReflectionType

--- a/src/TypeReflectors/MethodReturnTypeReflector.php
+++ b/src/TypeReflectors/MethodReturnTypeReflector.php
@@ -24,7 +24,7 @@ class MethodReturnTypeReflector extends TypeReflector
 
     protected function docblockRegex(): string
     {
-        return '/@return ((?:\s?[\w?|\\\\<>,]+(?:\[])?)+)/';
+        return '/@return ((?:\s?[\w?|\\\\<>,-]+(?:\[])?)+)/';
     }
 
     protected function getReflectionType(): ?ReflectionType

--- a/src/TypeReflectors/PropertyTypeReflector.php
+++ b/src/TypeReflectors/PropertyTypeReflector.php
@@ -24,7 +24,7 @@ class PropertyTypeReflector extends TypeReflector
 
     protected function docblockRegex(): string
     {
-        return '/@var ((?:\s?[\\w?|\\\\<>,]+(?:\[])?)+)/';
+        return '/@var ((?:\s?[\\w?|\\\\<>,-]+(?:\[])?)+)/';
     }
 
     protected function getReflectionType(): ?ReflectionType

--- a/tests/TypeReflectors/MethodParameterTypeReflectorTest.php
+++ b/tests/TypeReflectors/MethodParameterTypeReflectorTest.php
@@ -60,6 +60,7 @@ class MethodParameterTypeReflectorTest extends TestCase
              * @param ?int $nullable_int
              * @param int|float $union
              * @param int|float|null $nullable_union
+             * @param array<array-key, string> $array
              * @param $without_type
              */
             public function method(
@@ -67,6 +68,7 @@ class MethodParameterTypeReflectorTest extends TestCase
                 $nullable_int,
                 $union,
                 $nullable_union,
+                $array,
                 $without_type
             ) {
             }
@@ -95,8 +97,13 @@ class MethodParameterTypeReflectorTest extends TestCase
         );
 
         $this->assertEquals(
-            'any',
+            'array<array-key,string>',
             (string) MethodParameterTypeReflector::create($parameters[4])->reflect()
+        );
+
+        $this->assertEquals(
+            'any',
+            (string) MethodParameterTypeReflector::create($parameters[5])->reflect()
         );
     }
 

--- a/tests/TypeReflectors/MethodReturnTypeReflectorTest.php
+++ b/tests/TypeReflectors/MethodReturnTypeReflectorTest.php
@@ -97,6 +97,12 @@ class MethodReturnTypeReflectorTest extends TestCase
             {
                 return 42;
             }
+
+            /** @return array<array-key, string> */
+            public function m6()
+            {
+                return [];
+            }
         };
 
         $this->assertEquals(
@@ -122,6 +128,11 @@ class MethodReturnTypeReflectorTest extends TestCase
         $this->assertEquals(
             'any',
             (string) MethodReturnTypeReflector::create(new ReflectionMethod($class, 'm5'))->reflect()
+        );
+
+        $this->assertEquals(
+            'array<array-key,string>',
+            (string) MethodReturnTypeReflector::create(new ReflectionMethod($class, 'm6'))->reflect()
         );
     }
 

--- a/tests/TypeReflectors/PropertyTypeReflectorTest.php
+++ b/tests/TypeReflectors/PropertyTypeReflectorTest.php
@@ -63,6 +63,9 @@ class PropertyTypeReflectorTest extends TestCase
             public $p4;
 
             public $p5;
+
+            /** @var array<array-key, string> */
+            public $p6;
         };
 
         $this->assertEquals(
@@ -88,6 +91,11 @@ class PropertyTypeReflectorTest extends TestCase
         $this->assertEquals(
             'any',
             (string) PropertyTypeReflector::create(new ReflectionProperty($class, 'p5'))->reflect()
+        );
+
+        $this->assertEquals(
+            'array<array-key,string>',
+            (string) PropertyTypeReflector::create(new ReflectionProperty($class, 'p6'))->reflect()
         );
     }
 


### PR DESCRIPTION
Using `Collection<array-key, Type>` in a type docblock definition throws an error on reflection because the dash character `-` isn't included in the regex.
