### PR TITLE
feat: support non-backed enums

### DIFF
--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -5,6 +5,7 @@ namespace Spatie\TypeScriptTransformer\Transformers;
 use ReflectionClass;
 use ReflectionEnum;
 use ReflectionEnumBackedCase;
+use ReflectionEnumUnitCase;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
@@ -26,10 +27,6 @@ class EnumTransformer implements Transformer
         }
 
         $enum = (new ReflectionEnum($class->getName()));
-
-        if (! $enum->isBacked()) {
-            return null;
-        }
 
         return $this->config->shouldTransformToNativeEnums()
             ? $this->toEnum($enum, $name)
@@ -54,7 +51,7 @@ class EnumTransformer implements Transformer
     protected function toType(ReflectionEnum $enum, string $name): TransformedType
     {
         $options = array_map(
-            fn (ReflectionEnumBackedCase $case) => $this->toEnumValue($case),
+            fn (ReflectionEnumUnitCase $case) => $this->toEnumValue($case),
             $enum->getCases(),
         );
 
@@ -65,10 +62,12 @@ class EnumTransformer implements Transformer
         );
     }
 
-    protected function toEnumValue(ReflectionEnumBackedCase $case): string
+    protected function toEnumValue(ReflectionEnumUnitCase $case): string
     {
-        $value = $case->getBackingValue();
+        $value = $case instanceof ReflectionEnumBackedCase
+            ? $case->getBackingValue()
+            : $case->name;
 
-        return is_string($value) ? "'{$value}'" : "{$value}";
+        return \is_string($value) ? "'{$value}'" : "{$value}";
     }
 }

--- a/tests/FakeClasses/UnitEnum.php
+++ b/tests/FakeClasses/UnitEnum.php
@@ -5,7 +5,7 @@ namespace Spatie\TypeScriptTransformer\Tests\FakeClasses;
 /**
  * @typescript
  */
-enum Enum
+enum UnitEnum
 {
     case JS;
     case PHP;

--- a/tests/Transformers/EnumTransformerTest.php
+++ b/tests/Transformers/EnumTransformerTest.php
@@ -11,9 +11,9 @@ use function PHPUnit\Framework\assertTrue;
 use ReflectionClass;
 use Spatie\TypeScriptTransformer\Tests\FakeClasses\IntBackedEnum;
 use Spatie\TypeScriptTransformer\Tests\FakeClasses\StringBackedEnum;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\UnitEnum;
 use Spatie\TypeScriptTransformer\Transformers\EnumTransformer;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
-use UnitEnum;
 
 beforeEach(function () {
     if (\PHP_VERSION_ID < 80100) {
@@ -37,7 +37,7 @@ it('will only convert enums', function () {
     ));
 });
 
-it('does not transform a unit enum', function () {
+it('transforms a unit enum', function () {
     $transformer = new EnumTransformer(
         TypeScriptTransformerConfig::create()->transformToNativeEnums(false)
     );
@@ -47,7 +47,7 @@ it('does not transform a unit enum', function () {
         'Enum'
     );
 
-    assertNull($type);
+    assertEquals("'JS' | 'PHP'", $type->transformed);
 });
 
 it('can transform a backed enum into enum', function () {


### PR DESCRIPTION
This pull request add supports to `EnumTransformer` to also transform non-backed enums. I often had to back enums even though I didn't really need to back them, only to make them transformable.

Note: this PR is somewhat related to https://github.com/spatie/typescript-transformer/pull/42, [this line](https://github.com/spatie/typescript-transformer/pull/42/files#diff-7ac350a85bf6c499db670b4ca1c277869fbfd6ccf5b72d2e14f19a38c58b562fR43) should be changed to `UnitEnum` if this PR is accepted so the `DefaultCollector` actually works with all enums.