### PR TITLE
Ensure transformed types are unique

### DIFF
--- a/src/Actions/TranspileTypeToTypeScriptAction.php
+++ b/src/Actions/TranspileTypeToTypeScriptAction.php
@@ -66,7 +66,7 @@ class TranspileTypeToTypeScriptAction
             iterator_to_array($compound->getIterator())
         );
 
-        return join(' | ', $transformed);
+        return join(' | ', array_unique($transformed));
     }
 
     private function resolveListType(AbstractList $list): string

--- a/tests/FakeClasses/Integration/Dto.php
+++ b/tests/FakeClasses/Integration/Dto.php
@@ -34,6 +34,9 @@ class Dto extends DataTransferObject
     /** @var int|string */
     public $mixed;
 
+    /** @var int|float */
+    public $number;
+
     /** @var int[] */
     public $documented_array;
 

--- a/tests/__snapshots__/DtoTransformerTest__it_will_replace_types__1.txt
+++ b/tests/__snapshots__/DtoTransformerTest__it_will_replace_types__1.txt
@@ -10,6 +10,7 @@ array: Array<any>;
 none: any;
 documented_string: string;
 mixed: number | string;
+number: number;
 documented_array: Array<number>;
 mixed_with_array: number | string | Array<number | string>;
 array_with_null: Array<number | null>;

--- a/tests/__snapshots__/IntegrationTest__it_can_transform_to_es_modules__1.txt
+++ b/tests/__snapshots__/IntegrationTest__it_can_transform_to_es_modules__1.txt
@@ -10,6 +10,7 @@ array: Array<any>;
 none: any;
 documented_string: string;
 mixed: number | string;
+number: number;
 documented_array: Array<number>;
 mixed_with_array: number | string | Array<number | string>;
 array_with_null: Array<number | null>;

--- a/tests/__snapshots__/IntegrationTest__it_works__1.txt
+++ b/tests/__snapshots__/IntegrationTest__it_works__1.txt
@@ -11,6 +11,7 @@ array: Array<any>;
 none: any;
 documented_string: string;
 mixed: number | string;
+number: number;
 documented_array: Array<number>;
 mixed_with_array: number | string | Array<number | string>;
 array_with_null: Array<number | null>;


### PR DESCRIPTION
This PR ensures that if compound PHP types result in duplicate Typescript types, only unique types are used.

## Example
```php
class Dto {
    public int|float $number;
}
```

## Before:

```ts
{
    number: number | number
}
```

## After:
```ts
{
    number: number
}
```

