### PR TITLE
Hidden attribute

### DIFF
--- a/docs/dtos/typing-properties.md
+++ b/docs/dtos/typing-properties.md
@@ -252,3 +252,28 @@ Now all properties will be optional:
     name? : string;
 }
 ```
+
+## Hidden types
+
+You can make certain properties of a DTO hidden in TypeScript as such:
+
+```php
+class DataObject extends Data
+{
+    public function __construct(
+        public int $id,
+        #[Hidden]
+        public string $hidden,
+    )
+    {
+    }
+}
+```
+
+This will be transformed into:
+
+```tsx
+{
+    id : number;
+}
+```

--- a/src/Attributes/Hidden.php
+++ b/src/Attributes/Hidden.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Hidden
+{
+}

--- a/src/Transformers/DtoTransformer.php
+++ b/src/Transformers/DtoTransformer.php
@@ -4,6 +4,7 @@ namespace Spatie\TypeScriptTransformer\Transformers;
 
 use ReflectionClass;
 use ReflectionProperty;
+use Spatie\TypeScriptTransformer\Attributes\Hidden;
 use Spatie\TypeScriptTransformer\Attributes\Optional;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
@@ -58,6 +59,12 @@ class DtoTransformer implements Transformer
         return array_reduce(
             $this->resolveProperties($class),
             function (string $carry, ReflectionProperty $property) use ($isOptional, $missingSymbols) {
+                $isHidden = ! empty($property->getAttributes(Hidden::class));
+
+                if ($isHidden) {
+                    return $carry;
+                }
+
                 $isOptional = $isOptional || ! empty($property->getAttributes(Optional::class));
 
                 $transformed = $this->reflectionToTypeScript(

--- a/tests/Transformers/DtoTransformerTest.php
+++ b/tests/Transformers/DtoTransformerTest.php
@@ -6,6 +6,7 @@ use function PHPUnit\Framework\assertEquals;
 use function Spatie\Snapshots\assertMatchesSnapshot;
 use function Spatie\Snapshots\assertMatchesTextSnapshot;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
+use Spatie\TypeScriptTransformer\Attributes\Hidden;
 use Spatie\TypeScriptTransformer\Attributes\Optional;
 use Spatie\TypeScriptTransformer\Attributes\TypeScriptType;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
@@ -124,6 +125,22 @@ it('transforms all properties of a class with optional attribute to optional', f
 
     $type = $this->transformer->transform(
         new ReflectionClass(DummyOptionalDto::class),
+        'Typed'
+    );
+
+    assertMatchesSnapshot($type->transformed);
+});
+
+
+it('transforms properties to hidden ones when using hidden attribute', function () {
+    $class = new class () {
+        public string $visible;
+        #[Hidden]
+        public string $hidden;
+    };
+
+    $type = $this->transformer->transform(
+        new ReflectionClass($class),
         'Typed'
     );
 

--- a/tests/__snapshots__/DtoTransformerTest__it_transforms_properties_to_hidden_ones_when_using_hidden_attribute__1.txt
+++ b/tests/__snapshots__/DtoTransformerTest__it_transforms_properties_to_hidden_ones_when_using_hidden_attribute__1.txt
@@ -1,0 +1,3 @@
+{
+visible: string;
+}


### PR DESCRIPTION
I have a scenario where there are some properties I do not want certain properties to be included in the TypeScript generation. This adds an attribute for marking properties as hidden.