### PR TITLE
PhpdocTransformer

### DIFF
--- a/docs/laravel/installation-and-setup.md
+++ b/docs/laravel/installation-and-setup.md
@@ -96,5 +96,14 @@ return [
      */
     
     'transform_to_native_enums' => false,
+    
+    /*
+     * When set to true, the package will search for types by short name 
+     * when it doesn't find a type by FQN. 
+     * 
+     * This is useful when using the PhpDocTransformer, 
+     * since it doesn't know the FQN of the type (when 'use' statements are used).
+     */
+     'fuzzy_search' => false,
 ];
 ```

--- a/src/Actions/PersistTypesCollectionAction.php
+++ b/src/Actions/PersistTypesCollectionAction.php
@@ -20,7 +20,7 @@ class PersistTypesCollectionAction
 
         $writer = $this->config->getWriter();
 
-        (new ReplaceSymbolsInCollectionAction())->execute(
+        (new ReplaceSymbolsInCollectionAction($this->config))->execute(
             $collection,
             $writer->replacesSymbolsWithFullyQualifiedIdentifiers()
         );

--- a/src/Actions/ReplaceSymbolsInCollectionAction.php
+++ b/src/Actions/ReplaceSymbolsInCollectionAction.php
@@ -3,12 +3,19 @@
 namespace Spatie\TypeScriptTransformer\Actions;
 
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class ReplaceSymbolsInCollectionAction
 {
+    private TypeScriptTransformerConfig $config;
+
+    public function __construct(TypeScriptTransformerConfig $config)
+    {
+        $this->config = $config;
+    }
     public function execute(TypesCollection $collection, $withFullyQualifiedNames = true): TypesCollection
     {
-        $replaceSymbolsInTypeAction = new ReplaceSymbolsInTypeAction($collection, $withFullyQualifiedNames);
+        $replaceSymbolsInTypeAction = new ReplaceSymbolsInTypeAction($this->config, $collection, $withFullyQualifiedNames);
 
         foreach ($collection as $type) {
             $type->transformed = $replaceSymbolsInTypeAction->execute($type);

--- a/src/Exceptions/FuzzySearchFailed.php
+++ b/src/Exceptions/FuzzySearchFailed.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Exceptions;
+
+class FuzzySearchFailed extends \Exception
+{
+    public static function create(string $shortName): self
+    {
+        return new self("There is more then one Type with short name '{$shortName}'. Use FQN in phpdoc to avoid this.");
+    }
+}

--- a/src/Structures/TypesCollection.php
+++ b/src/Structures/TypesCollection.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Spatie\TypeScriptTransformer\Exceptions\FuzzySearchFailed;
 use Spatie\TypeScriptTransformer\Exceptions\SymbolAlreadyExists;
 
 class TypesCollection implements ArrayAccess, Countable, IteratorAggregate
@@ -63,6 +64,20 @@ class TypesCollection implements ArrayAccess, Countable, IteratorAggregate
     public function count(): int
     {
         return count($this->types);
+    }
+
+    public function getTypeByShortName(string $shortName): ?TransformedType
+    {
+        $types = array_filter($this->types, function (TransformedType $type) use($shortName) {
+            return $type->name === $shortName;
+        });
+        if(count($types) > 1) {
+            throw new FuzzySearchFailed($shortName);
+        }else if (count($types) === 1) {
+            return array_pop($types);
+        }else {
+            return null;
+        }
     }
 
     protected function ensureTypeCanBeAdded(TransformedType $type): void

--- a/src/Transformers/PhpDocTransformer.php
+++ b/src/Transformers/PhpDocTransformer.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Transformers;
+
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\Property;
+use phpDocumentor\Reflection\DocBlock\Tags\PropertyRead;
+use phpDocumentor\Reflection\DocBlock\Tags\PropertyWrite;
+use phpDocumentor\Reflection\DocBlockFactory;
+use ReflectionClass;
+use Spatie\TypeScriptTransformer\Attributes\Optional;
+use Spatie\TypeScriptTransformer\Exceptions\UnableToTransformUsingAttribute;
+use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
+use Spatie\TypeScriptTransformer\TypeProcessors\DtoCollectionTypeProcessor;
+use Spatie\TypeScriptTransformer\TypeProcessors\ReplaceDefaultsTypeProcessor;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+
+class PhpDocTransformer implements Transformer
+{
+    use TransformsTypes;
+
+    public $none = null;
+
+    protected TypeScriptTransformerConfig $config;
+
+    public function __construct(TypeScriptTransformerConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    public function transform(ReflectionClass $class, string $name): ?TransformedType
+    {
+        if (!$this->canTransform($class)) {
+            return null;
+        }
+
+        $missingSymbols = new MissingSymbolsCollection();
+        $tags = $this->getTags($class);
+
+        $type = join([
+            $this->transformProperties($class, $tags, $missingSymbols),
+            $this->transformMethods($class, $tags, $missingSymbols),
+            $this->transformExtra($class, $tags, $missingSymbols),
+        ]);
+
+        return TransformedType::create(
+            $class,
+            $name,
+            "{" . PHP_EOL . $type . "}",
+            $missingSymbols
+        );
+    }
+
+    protected function canTransform(ReflectionClass $class): bool
+    {
+        $hasPhpDoc = $class->getDocComment();
+        $hasProperties = $hasPhpDoc && count($this->getTags($class)) > 0;
+
+        return $hasPhpDoc && $hasProperties;
+    }
+
+    protected function getTags(ReflectionClass $class): array
+    {
+        $docComment = $class->getDocComment();
+
+        $factory = DocBlockFactory::createInstance();
+        $docBlock = $factory->create($docComment);
+
+        return $docBlock->getTags();
+    }
+
+    protected function transformProperties(ReflectionClass          $class,
+                                           array                    $tags,
+                                           MissingSymbolsCollection $missingSymbols): string
+    {
+        $isOptional = !empty($class->getAttributes(Optional::class));
+
+        return array_reduce($tags, function (string $carry, Tag $tag) use ($class, $missingSymbols, $isOptional) {
+            /** @var Property|PropertyRead|PropertyWrite $tag */
+
+            if (!in_array($tag->getName(), [
+                'property',
+                'property-read',
+            ])) {
+                return $carry;
+            }
+
+            $type = null;
+            foreach ($this->typeProcessors() as $processor) {
+                $type = $processor->process(
+                    $tag->getType(),
+                    new \ReflectionProperty($this, 'none'),
+                    $missingSymbols
+                );
+            }
+
+            if ($type === null) {
+                return null;
+            }
+
+            $transformed = $this->typeToTypeScript($type, $missingSymbols, $class);
+
+            return $isOptional
+                ? "{$carry}{$this->getNameFromTag($tag)}?: {$transformed};" . PHP_EOL
+                : "{$carry}{$this->getNameFromTag($tag)}: {$transformed};" . PHP_EOL;
+
+        }, '');
+    }
+
+    protected function transformMethods(
+        ReflectionClass          $class,
+        array                    $tags,
+        MissingSymbolsCollection $missingSymbols
+    ): string
+    {
+        return '';
+    }
+
+    protected function transformExtra(
+        ReflectionClass          $class,
+        array                    $tags,
+        MissingSymbolsCollection $missingSymbols
+    ): string
+    {
+        return '';
+    }
+
+    protected function typeProcessors(): array
+    {
+        return [
+            new ReplaceDefaultsTypeProcessor(
+                $this->config->getDefaultTypeReplacements()
+            ),
+            new DtoCollectionTypeProcessor(),
+        ];
+    }
+
+    protected function getNameFromTag(Property|PropertyRead|PropertyWrite $tag)
+    {
+        if ($tag->getVariableName()) {
+            return $tag->getVariableName();
+        }
+        if (!$tag->getDescription()) {
+            throw UnableToTransformUsingAttribute::create($tag);
+        }
+        return preg_split('/(\s|\n)/', trim($tag->getDescription()))[0];
+    }
+}

--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -29,6 +29,8 @@ class TypeScriptTransformerConfig
 
     private bool $transformToNativeEnums = false;
 
+    private bool $fuzzyTypeSearch = false;
+
     public static function create(): self
     {
         return new self();
@@ -90,6 +92,13 @@ class TypeScriptTransformerConfig
         return $this;
     }
 
+    public function fuzzyTypeSearch(bool $fuzzySearch = false): self
+    {
+        $this->fuzzyTypeSearch = $fuzzySearch;
+
+        return $this;
+    }
+
     public function getAutoDiscoverTypesPaths(): array
     {
         return $this->autoDiscoverTypesPaths;
@@ -113,7 +122,9 @@ class TypeScriptTransformerConfig
 
     public function getWriter(): Writer
     {
-        return new $this->writer;
+        return method_exists($this->writer, '__construct')
+            ? new $this->writer($this)
+            : new $this->writer;
     }
 
     public function getOutputFile(): string
@@ -161,5 +172,10 @@ class TypeScriptTransformerConfig
     public function shouldTransformToNativeEnums(): bool
     {
         return $this->transformToNativeEnums;
+    }
+
+    public function fuzzyTypeSearchEnabled(): bool
+    {
+        return $this->fuzzyTypeSearch;
     }
 }

--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -5,12 +5,20 @@ namespace Spatie\TypeScriptTransformer\Writers;
 use Spatie\TypeScriptTransformer\Actions\ReplaceSymbolsInCollectionAction;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class TypeDefinitionWriter implements Writer
 {
+    private TypeScriptTransformerConfig $config;
+
+    public function __construct(TypeScriptTransformerConfig $config)
+    {
+        $this->config = $config;
+    }
+
     public function format(TypesCollection $collection): string
     {
-        (new ReplaceSymbolsInCollectionAction())->execute($collection);
+        (new ReplaceSymbolsInCollectionAction($this->config))->execute($collection);
 
         [$namespaces, $rootTypes] = $this->groupByNamespace($collection);
 

--- a/tests/Actions/ReplaceSymbolsInCollectionActionTest.php
+++ b/tests/Actions/ReplaceSymbolsInCollectionActionTest.php
@@ -1,12 +1,13 @@
 <?php
 
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 use function PHPUnit\Framework\assertEquals;
 use Spatie\TypeScriptTransformer\Actions\ReplaceSymbolsInCollectionAction;
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
 use Spatie\TypeScriptTransformer\Tests\Fakes\FakeTransformedType;
 
 it('can replace missing symbols', function () {
-    $action = new ReplaceSymbolsInCollectionAction();
+    $action = new ReplaceSymbolsInCollectionAction(TypeScriptTransformerConfig::create());
 
     $collection = TypesCollection::create();
 
@@ -24,7 +25,7 @@ it('can replace missing symbols', function () {
 });
 
 it('can replace missing symbols without fully qualified names', function () {
-    $action = new ReplaceSymbolsInCollectionAction();
+    $action = new ReplaceSymbolsInCollectionAction(TypeScriptTransformerConfig::create());
 
     $collection = TypesCollection::create();
 

--- a/tests/Transformers/PhpDocTransformerTest.php
+++ b/tests/Transformers/PhpDocTransformerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+
+use Spatie\TypeScriptTransformer\Transformers\PhpDocTransformer;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+use function PHPUnit\Framework\assertNotNull;
+use function PHPUnit\Framework\assertNull;
+
+beforeEach(function () {
+    $config = TypeScriptTransformerConfig::create();
+
+    $this->transformer = new PhpDocTransformer($config);
+});
+
+it('will replace types with PhpDoc comment', function () {
+    /**
+     * @property string $date
+     * @property string $time
+     */
+    class phpDoc
+    {
+    }
+
+    class noDoc
+    {
+        public string $date;
+        public string $time;
+    }
+
+
+    assertNotNull($this->transformer->transform(new ReflectionClass(phpDoc::class), 'Typed'));
+    assertNull($this->transformer->transform(new ReflectionClass(noDoc::class), 'Typed'));
+});


### PR DESCRIPTION
I have added a Transformer to transform properties from PhpDoc Comments.
This is useful for ORM's like eloquent, since Eloquent models don't have their properties defined in code.

Since it's not possible to get the FQN from Short names in a PHPDoc comment, I also added a fuzzy search for types in the TypesCollection.
When enabled, the ReplaceSymbolsInTypeAction will try to find the missing type by short name, when it isn't found by FQN.
If nothing is found, it will inert 'any' like before.
If it finds more than one, an exception is thrown.
