### PR TITLE
Add `DtoTransformer@transformPropertyName()`

### DIFF
--- a/src/Transformers/DtoTransformer.php
+++ b/src/Transformers/DtoTransformer.php
@@ -77,9 +77,11 @@ class DtoTransformer implements Transformer
                     return $carry;
                 }
 
+                $propertyName = $this->transformPropertyName($property, $missingSymbols);
+
                 return $isOptional
-                    ? "{$carry}{$property->getName()}?: {$transformed};" . PHP_EOL
-                    : "{$carry}{$property->getName()}: {$transformed};" . PHP_EOL;
+                    ? "{$carry}{$propertyName}?: {$transformed};" . PHP_EOL
+                    : "{$carry}{$propertyName}: {$transformed};" . PHP_EOL;
             },
             ''
         );
@@ -97,6 +99,13 @@ class DtoTransformer implements Transformer
         MissingSymbolsCollection $missingSymbols
     ): string {
         return '';
+    }
+
+    protected function transformPropertyName(
+        ReflectionProperty $property,
+        MissingSymbolsCollection $missingSymbols
+    ): string {
+        return $property->getName();
     }
 
     protected function typeProcessors(): array


### PR DESCRIPTION
I'm working on a proof of concept to be able to build Laravel Requests and Resources that can be shared with our frontend team as Typescript types.

The problem is that in PHP-land, we typically use camelCase, but all of the properties passed via the API use snake_case. Was thinking that we could locally create a new attribute and then check that within our code. Might look something like this:

```php
#[TypeScript]
class SomeRequest extends Request
{
    #[TypeScriptProperty('user_id')]
    public int $userId;

    public function rules(): array
    {
        return [
            'user_id' => ['int'],
            // ... other rules
        ];
    }

    protected function passedValidation(): void
    {
        $this->userId = $this->validated('user_id');
    }
}
```

The proposal here is just to make it easier for us to override this locally by checking if the attribute is applied within the `DtoTransform@transformPropertyName()` method.

Happy to add in that attribute as well once we get it up and running.