### PR TITLE
Don't generate if an enum has no cases yet

### DIFF
--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -31,7 +31,7 @@ class EnumTransformer implements Transformer
             return null;
         }
 
-        if (empty($enum->getCases()) {
+        if (empty($enum->getCases())) {
             return null;
         }
 

--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -31,6 +31,10 @@ class EnumTransformer implements Transformer
             return null;
         }
 
+        if (empty($enum->getCases()) {
+            return null;
+        }
+
         return $this->config->shouldTransformToNativeEnums()
             ? $this->toEnum($enum, $name)
             : $this->toType($enum, $name);


### PR DESCRIPTION
We happen to have a placeholder backed enum in our code base with no cases yet.

The current output in our generated.d.ts when `'transform_to_native_enums' => false` looks like:

```ts
declare namespace ... {
export type Placeholder = ; // Syntax error as nothing between '=' and ';'
}
```

This is a syntax error and might be causing type inference issues in the rest of our application.