### PR TITLE
don't include docs directory in archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,5 @@
 /.editorconfig      export-ignore
 /.php.cs            export-ignore
 /.github            export-ignore
+/docs               export-ignore
 


### PR DESCRIPTION
esp. docs/images/header.jpg is quite huge (530 kB) and not needed for production builds