### PR TITLE
feat: allow overriding of actions

### DIFF
--- a/src/Actions/PersistTypesCollectionAction.php
+++ b/src/Actions/PersistTypesCollectionAction.php
@@ -3,6 +3,7 @@
 namespace Spatie\TypeScriptTransformer\Actions;
 
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class PersistTypesCollectionAction
@@ -20,7 +21,8 @@ class PersistTypesCollectionAction
 
         $writer = $this->config->getWriter();
 
-        (new ReplaceSymbolsInCollectionAction())->execute(
+        TypeScriptTransformer::make(ReplaceSymbolsInCollectionAction::class)
+            ->execute(
             $collection,
             $writer->replacesSymbolsWithFullyQualifiedIdentifiers()
         );

--- a/src/Actions/ReplaceSymbolsInCollectionAction.php
+++ b/src/Actions/ReplaceSymbolsInCollectionAction.php
@@ -3,12 +3,12 @@
 namespace Spatie\TypeScriptTransformer\Actions;
 
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
-
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
 class ReplaceSymbolsInCollectionAction
 {
     public function execute(TypesCollection $collection, $withFullyQualifiedNames = true): TypesCollection
     {
-        $replaceSymbolsInTypeAction = new ReplaceSymbolsInTypeAction($collection, $withFullyQualifiedNames);
+        $replaceSymbolsInTypeAction = TypeScriptTransformer::make(ReplaceSymbolsInTypeAction::class, $collection, $withFullyQualifiedNames);
 
         foreach ($collection as $type) {
             $type->transformed = $replaceSymbolsInTypeAction->execute($type);

--- a/src/Actions/ResolveTypesCollectionAction.php
+++ b/src/Actions/ResolveTypesCollectionAction.php
@@ -8,6 +8,7 @@ use ReflectionClass;
 use Spatie\TypeScriptTransformer\Exceptions\NoAutoDiscoverTypesPathsDefined;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 use Symfony\Component\Finder\Finder;
 
@@ -61,7 +62,7 @@ class ResolveTypesCollectionAction
 
         foreach ($this->finder->in($paths) as $fileInfo) {
             try {
-                $classes = (new ResolveClassesInPhpFileAction())->execute($fileInfo);
+                $classes = TypeScriptTransformer::make(ResolveClassesInPhpFileAction::class)->execute($fileInfo);
 
                 foreach ($classes as $name) {
                     yield $name => new ReflectionClass($name);

--- a/src/Collectors/DefaultCollector.php
+++ b/src/Collectors/DefaultCollector.php
@@ -10,6 +10,7 @@ use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\Transformers\Transformer;
 use Spatie\TypeScriptTransformer\TypeReflectors\ClassTypeReflector;
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
 
 class DefaultCollector extends Collector
 {
@@ -39,7 +40,8 @@ class DefaultCollector extends Collector
         $name = $reflector->getName();
         $nullablesAreOptional = $this->config->shouldConsiderNullAsOptional();
 
-        $transpiler = new TranspileTypeToTypeScriptAction(
+        $transpiler = TypeScriptTransformer::make(
+            TranspileTypeToTypeScriptAction::class,
             $missingSymbols,
             $nullablesAreOptional,
             $name

--- a/src/Transformers/TransformsTypes.php
+++ b/src/Transformers/TransformsTypes.php
@@ -10,6 +10,7 @@ use Spatie\TypeScriptTransformer\Actions\TranspileTypeToTypeScriptAction;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\TypeProcessors\TypeProcessor;
 use Spatie\TypeScriptTransformer\TypeReflectors\TypeReflector;
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
 
 trait TransformsTypes
 {
@@ -65,7 +66,8 @@ trait TransformsTypes
         bool $nullablesAreOptional = false,
         ?string $currentClass = null,
     ): string {
-        $transpiler = new TranspileTypeToTypeScriptAction(
+        $transpiler = TypeScriptTransformer::make(
+            TranspileTypeToTypeScriptAction::class,
             $missingSymbolsCollection,
             $nullablesAreOptional,
             $currentClass,

--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -5,12 +5,13 @@ namespace Spatie\TypeScriptTransformer\Writers;
 use Spatie\TypeScriptTransformer\Actions\ReplaceSymbolsInCollectionAction;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
-
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
 class TypeDefinitionWriter implements Writer
 {
     public function format(TypesCollection $collection): string
     {
-        (new ReplaceSymbolsInCollectionAction())->execute($collection);
+        
+        TypeScriptTransformer::make(ReplaceSymbolsInCollectionAction::class)->execute($collection);
 
         [$namespaces, $rootTypes] = $this->groupByNamespace($collection);
 

--- a/tests/TypescriptTransformerTest.php
+++ b/tests/TypescriptTransformerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+
+use Spatie\TypeScriptTransformer\Actions\ReplaceSymbolsInCollectionAction;
+use Spatie\TypeScriptTransformer\Actions\ReplaceSymbolsInTypeAction;
+use Spatie\TypeScriptTransformer\Actions\ResolveClassesInPhpFileAction;
+
+use function PHPUnit\Framework\assertInstanceOf;
+use Spatie\TypeScriptTransformer\TypeScriptTransformer;
+
+it('can override actions', function () {
+    
+    //Default resolultion works.
+   $instance = TypeScriptTransformer::make(ReplaceSymbolsInCollectionAction::class);
+    assertInstanceOf(ReplaceSymbolsInCollectionAction::class, $instance);
+
+    //Can be overridden
+    TypescriptTransformer::override(ReplaceSymbolsInCollectionAction::class, ResolveClassesInPhpFileAction::class);
+    $instance = TypeScriptTransformer::make(ReplaceSymbolsInCollectionAction::class);
+    assertInstanceOf(ResolveClassesInPhpFileAction::class, $instance);
+
+    //Can be set back to default.
+    TypeScriptTransformer::override(ReplaceSymbolsInCollectionAction::class, ReplaceSymbolsInCollectionAction::class);
+    $instance = TypeScriptTransformer::make(ReplaceSymbolsInCollectionAction::class);
+    assertInstanceOf(ReplaceSymbolsInCollectionAction::class, $instance);
+   
+});
+


### PR DESCRIPTION
I've implemented a very simple hotswap/app container for resolving and replacing actions in the transformer. This allows people to extend, tweak or shortcut isolated pieces of the flow, without having to maintain full forks.