### PR TITLE
fix: No quotes for the enum case according to typescriptlang.org

### DIFF
--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -43,7 +43,7 @@ class EnumTransformer implements Transformer
     protected function toEnum(ReflectionEnum $enum, string $name): TransformedType
     {
         $options = array_map(
-            fn (ReflectionEnumBackedCase $case) => "'{$case->getName()}' = {$this->toEnumValue($case)}",
+            fn (ReflectionEnumBackedCase $case) => "{$case->getName()} = {$this->toEnumValue($case)}",
             $enum->getCases()
         );
 

--- a/tests/Transformers/EnumTransformerTest.php
+++ b/tests/Transformers/EnumTransformerTest.php
@@ -60,7 +60,7 @@ it('can transform a backed enum into enum', function () {
         'Enum'
     );
 
-    assertEquals("'JS' = 'js', 'PHP' = 'php', 'BackslashesTest' = 'backslashes\\\\test'", $type->transformed);
+    assertEquals("JS = 'js', PHP = 'php', BackslashesTest = 'backslashes\\\\test'", $type->transformed);
     assertTrue($type->missingSymbols->isEmpty());
     assertFalse($type->isInline);
     assertEquals('enum', $type->keyword);
@@ -92,7 +92,7 @@ it('can transform a backed enum with integers into an enm', function () {
         'Enum'
     );
 
-    assertEquals("'JS' = 1, 'PHP' = 2", $type->transformed);
+    assertEquals("JS = 1, PHP = 2", $type->transformed);
     assertTrue($type->missingSymbols->isEmpty());
     assertFalse($type->isInline);
     assertEquals('enum', $type->keyword);


### PR DESCRIPTION
Hi there,

i think the enum transformers did a little bit too much. It added quotes around the enum case in typescript declartions like this:
```ts
declare namespace App.Enums {
  export enum AttachmentType { 'TRACE' = 'trace' };
  export enum CrawlerLevel { 'BASE' = 0, 'ONE' = 1, 'TWO' = 2, 'THREE' = 3, 'FOUR' = 4 };
}
```
but according to the [typescript handbook](https://www.typescriptlang.org/docs/handbook/enums.html) the enum cases should miss the quotes! Like this:
```ts
declare namespace App.Enums {
  export enum AttachmentType { TRACE = 'trace' };
  export enum CrawlerLevel { BASE = 0, ONE = 1, TWO = 2, THREE = 3, FOUR = 4 };
}
```