### PR TITLE
Fix: EnumTransformer properly handling single-quotes in backed enum string values

### DIFF
--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -73,6 +73,22 @@ class EnumTransformer implements Transformer
     {
         $value = $case->getBackingValue();
 
-        return is_string($value) ? "'" . str_replace('\\', '\\\\', $value) . "'" : "{$value}";
+        $newValue = "";
+
+        if (!is_string($value)) {
+            return "{$value}";
+        }
+
+        for ($i = 0; $i < strlen($value); $i++) {
+            $char = $value[$i];
+
+            match ($char) {
+                '\\' => $newValue .= '\\\\',
+                '\'' => $newValue .= '\\\'',
+                default => $newValue .= $char,
+            };
+        }
+
+        return "'" . $newValue . "'";
     }
 }

--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -82,10 +82,10 @@ class EnumTransformer implements Transformer
         for ($i = 0; $i < strlen($value); $i++) {
             $char = $value[$i];
 
-            match ($char) {
-                '\\' => $newValue .= '\\\\',
-                '\'' => $newValue .= '\\\'',
-                default => $newValue .= $char,
+            $newValue .= match ($char) {
+                '\\' => '\\\\',
+                '\'' => '\\\'',
+                default => $char,
             };
         }
 

--- a/tests/FakeClasses/StringBackedEnumWithSingleQuotes.php
+++ b/tests/FakeClasses/StringBackedEnumWithSingleQuotes.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\FakeClasses;
+
+enum StringBackedEnumWithSingleQuotes: string
+{
+    case NO_QUOTE = 'no quote';
+    case HAS_QUOTE = 'has quote \'';
+}

--- a/tests/Transformers/EnumTransformerTest.php
+++ b/tests/Transformers/EnumTransformerTest.php
@@ -11,6 +11,7 @@ use function PHPUnit\Framework\assertTrue;
 use ReflectionClass;
 use Spatie\TypeScriptTransformer\Tests\FakeClasses\IntBackedEnum;
 use Spatie\TypeScriptTransformer\Tests\FakeClasses\StringBackedEnum;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\StringBackedEnumWithSingleQuotes;
 use Spatie\TypeScriptTransformer\Transformers\EnumTransformer;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 use UnitEnum;
@@ -82,7 +83,7 @@ it('can transform a backed enum into a union', function () {
     assertEquals('type', $type->keyword);
 });
 
-it('can transform a backed enum with integers into an enm', function () {
+it('can transform a backed enum with integers into an enum', function () {
     $transformer = new EnumTransformer(
         TypeScriptTransformerConfig::create()->transformToNativeEnums(true)
     );
@@ -109,6 +110,38 @@ it('can transform a backed enum with integers into a union', function () {
     );
 
     assertEquals("1 | 2", $type->transformed);
+    assertTrue($type->missingSymbols->isEmpty());
+    assertFalse($type->isInline);
+    assertEquals('type', $type->keyword);
+});
+
+it('can transform a backed enum with strings with single-quotes into a enum', function () {
+    $transformer = new EnumTransformer(
+        TypeScriptTransformerConfig::create()->transformToNativeEnums(true)
+    );
+
+    $type = $transformer->transform(
+        new ReflectionClass(StringBackedEnumWithSingleQuotes::class),
+        'Enum'
+    );
+
+    assertEquals("'NO_QUOTE' = 'no quote', 'HAS_QUOTE' = 'has quote \''", $type->transformed);
+    assertTrue($type->missingSymbols->isEmpty());
+    assertFalse($type->isInline);
+    assertEquals('enum', $type->keyword);
+});
+
+it('can transform a backed enum with strings with single-quotes into a union', function () {
+    $transformer = new EnumTransformer(
+        TypeScriptTransformerConfig::create()->transformToNativeEnums(false)
+    );
+
+    $type = $transformer->transform(
+        new ReflectionClass(StringBackedEnumWithSingleQuotes::class),
+        'Enum'
+    );
+
+    assertEquals("'no quote' | 'has quote \''", $type->transformed);
     assertTrue($type->missingSymbols->isEmpty());
     assertFalse($type->isInline);
     assertEquals('type', $type->keyword);


### PR DESCRIPTION
closes #99 

Sorry if I missed anything in this pull request, this is my first contribution to an open-source project. :)

I modified the EnumTransformer's `toEnumValue` method so it looks at each character individually in case it needs to add something different to the string for it to work in TS. This way, in can be extended more easily for broken characters in the future.