### PR TITLE
Introduce Compactors to shorten output namespaces and type names

### DIFF
--- a/src/Collectors/Collector.php
+++ b/src/Collectors/Collector.php
@@ -3,6 +3,7 @@
 namespace Spatie\TypeScriptTransformer\Collectors;
 
 use ReflectionClass;
+use Spatie\TypeScriptTransformer\Compactors\ConfigCompactor;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
@@ -10,9 +11,12 @@ abstract class Collector
 {
     protected TypeScriptTransformerConfig $config;
 
+    protected ConfigCompactor $compactor;
+
     public function __construct(TypeScriptTransformerConfig $config)
     {
         $this->config = $config;
+        $this->compactor = new ConfigCompactor($config);
     }
 
     abstract public function getTransformedType(ReflectionClass $class): ?TransformedType;

--- a/src/Collectors/DefaultCollector.php
+++ b/src/Collectors/DefaultCollector.php
@@ -49,6 +49,7 @@ class DefaultCollector extends Collector
             $reflector->getReflectionClass(),
             $reflector->getName(),
             $transpiler->execute($reflector->getType()),
+            $this->compactor,
             $missingSymbols
         );
     }

--- a/src/Compactors/Compactor.php
+++ b/src/Compactors/Compactor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Compactors;
+
+/**
+ * Shortens namespace of a typescript identifier
+ */
+interface Compactor
+{
+    public function compact(string $typescriptIdentifier): string;
+}

--- a/src/Compactors/ConfigCompactor.php
+++ b/src/Compactors/ConfigCompactor.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Compactors;
+
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+
+class ConfigCompactor implements Compactor
+{
+
+    protected ?array $prefixes = null;
+
+    protected ?array $suffixes = null;
+
+    protected TypeScriptTransformerConfig $config;
+
+    public function __construct(TypeScriptTransformerConfig $config) {
+        $this->config = $config;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getPrefixes(): array {
+        if ($this->prefixes === null) {
+            $this->prefixes = array_map(
+                function(string $prefix): string {
+                    $prefix = str_replace("\\", ".", $prefix);
+                    if (!str_ends_with($prefix, ".")) {
+                        $prefix .= ".";
+                    }
+                    return $prefix;
+                },
+                $this->config->getCompactorPrefixes()
+            );
+        }
+        return $this->prefixes;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSuffixes(): array {
+        if ($this->suffixes === null) {
+            $this->suffixes = $this->config->getCompactorSuffixes();
+        }
+        return $this->suffixes;
+    }
+
+    public function compact(
+        string $typescriptIdentifier
+    ): string {
+        $matchingPrefix = '';
+        $matchingSuffix = '';
+        foreach ($this->getPrefixes() as $prefix) {
+            if (str_starts_with($typescriptIdentifier, $prefix)) {
+                $matchingPrefix = $prefix;
+                break;
+            }
+        }
+        foreach ($this->getSuffixes() as $suffix) {
+            if (str_ends_with($typescriptIdentifier, $suffix)) {
+                $matchingSuffix = $suffix;
+                break;
+            }
+        }
+        if ($matchingSuffix !== '') {
+            $typescriptIdentifier = substr($typescriptIdentifier, 0, -strlen($matchingSuffix));
+        }
+        $substr = substr($typescriptIdentifier, strlen($matchingPrefix));
+        return $substr;
+    }
+
+}

--- a/src/Compactors/IdentityCompactor.php
+++ b/src/Compactors/IdentityCompactor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Compactors;
+
+class IdentityCompactor implements Compactor
+{
+
+    public function compact(string $typescriptIdentifier): string {
+        return $typescriptIdentifier;
+    }
+
+}

--- a/src/Structures/TransformedType.php
+++ b/src/Structures/TransformedType.php
@@ -3,6 +3,7 @@
 namespace Spatie\TypeScriptTransformer\Structures;
 
 use ReflectionClass;
+use Spatie\TypeScriptTransformer\Compactors\Compactor;
 
 class TransformedType
 {
@@ -14,6 +15,8 @@ class TransformedType
 
     public MissingSymbolsCollection $missingSymbols;
 
+    public Compactor $compactor;
+
     public bool $isInline;
 
     public string $keyword;
@@ -24,26 +27,29 @@ class TransformedType
         ReflectionClass $class,
         string $name,
         string $transformed,
+        Compactor $compactor,
         ?MissingSymbolsCollection $missingSymbols = null,
         bool $inline = false,
         string $keyword = 'type',
         bool $trailingSemicolon = true,
     ): self {
-        return new self($class, $name, $transformed, $missingSymbols ?? new MissingSymbolsCollection(), $inline, $keyword, $trailingSemicolon);
+        return new self($class, $compactor->compact($name), $transformed, $compactor, $missingSymbols ?? new MissingSymbolsCollection(), $inline, $keyword, $trailingSemicolon);
     }
 
     public static function createInline(
         ReflectionClass $class,
         string $transformed,
+        Compactor $compactor,
         ?MissingSymbolsCollection $missingSymbols = null
     ): self {
-        return new self($class, null, $transformed, $missingSymbols ?? new MissingSymbolsCollection(), true);
+        return new self($class, null, $transformed, $compactor, $missingSymbols ?? new MissingSymbolsCollection(), true);
     }
 
     public function __construct(
         ReflectionClass $class,
         ?string $name,
         string $transformed,
+        Compactor $compactor,
         MissingSymbolsCollection $missingSymbols,
         bool $isInline,
         string $keyword = 'type',
@@ -53,6 +59,7 @@ class TransformedType
         $this->name = $name;
         $this->transformed = $transformed;
         $this->missingSymbols = $missingSymbols;
+        $this->compactor = $compactor;
         $this->isInline = $isInline;
         $this->keyword = $keyword;
         $this->trailingSemicolon = $trailingSemicolon;
@@ -84,7 +91,9 @@ class TransformedType
             [$this->name]
         );
 
-        return implode('.', $segments);
+        return $this->compactor->compact(
+            implode('.', $segments)
+        );
     }
 
     public function replaceSymbol(string $class, string $replacement): void

--- a/src/Transformers/DtoTransformer.php
+++ b/src/Transformers/DtoTransformer.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use ReflectionProperty;
 use Spatie\TypeScriptTransformer\Attributes\Hidden;
 use Spatie\TypeScriptTransformer\Attributes\Optional;
+use Spatie\TypeScriptTransformer\Compactors\ConfigCompactor;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\TypeProcessors\DtoCollectionTypeProcessor;
@@ -18,9 +19,12 @@ class DtoTransformer implements Transformer
 
     protected TypeScriptTransformerConfig $config;
 
+    protected ConfigCompactor $compactor;
+
     public function __construct(TypeScriptTransformerConfig $config)
     {
         $this->config = $config;
+        $this->compactor = new ConfigCompactor($config);
     }
 
     public function transform(ReflectionClass $class, string $name): ?TransformedType
@@ -30,7 +34,6 @@ class DtoTransformer implements Transformer
         }
 
         $missingSymbols = new MissingSymbolsCollection();
-
         $type = join([
             $this->transformProperties($class, $missingSymbols),
             $this->transformMethods($class, $missingSymbols),
@@ -41,6 +44,7 @@ class DtoTransformer implements Transformer
             $class,
             $name,
             "{" . PHP_EOL . $type . "}",
+            $this->compactor,
             $missingSymbols
         );
     }

--- a/src/Transformers/EnumTransformer.php
+++ b/src/Transformers/EnumTransformer.php
@@ -5,13 +5,17 @@ namespace Spatie\TypeScriptTransformer\Transformers;
 use ReflectionClass;
 use ReflectionEnum;
 use ReflectionEnumBackedCase;
+use Spatie\TypeScriptTransformer\Compactors\ConfigCompactor;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class EnumTransformer implements Transformer
 {
+    protected ConfigCompactor $compactor;
+
     public function __construct(protected TypeScriptTransformerConfig $config)
     {
+        $this->compactor = new ConfigCompactor($config);
     }
 
     public function transform(ReflectionClass $class, string $name): ?TransformedType
@@ -46,6 +50,7 @@ class EnumTransformer implements Transformer
             $enum,
             $name,
             implode(', ', $options),
+            $this->compactor,
             keyword: 'enum'
         );
     }
@@ -60,7 +65,8 @@ class EnumTransformer implements Transformer
         return TransformedType::create(
             $enum,
             $name,
-            implode(' | ', $options)
+            implode(' | ', $options),
+            $this->compactor
         );
     }
 

--- a/src/Transformers/MyclabsEnumTransformer.php
+++ b/src/Transformers/MyclabsEnumTransformer.php
@@ -4,13 +4,17 @@ namespace Spatie\TypeScriptTransformer\Transformers;
 
 use MyCLabs\Enum\Enum;
 use ReflectionClass;
+use Spatie\TypeScriptTransformer\Compactors\ConfigCompactor;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class MyclabsEnumTransformer implements Transformer
 {
+    protected ConfigCompactor $compactor;
+
     public function __construct(protected TypeScriptTransformerConfig $config)
     {
+        $this->compactor = new ConfigCompactor($config);
     }
 
     public function transform(ReflectionClass $class, string $name): ?TransformedType
@@ -39,6 +43,7 @@ class MyclabsEnumTransformer implements Transformer
             $class,
             $name,
             implode(', ', $options),
+            $this->compactor,
             keyword: 'enum'
         );
     }
@@ -56,7 +61,8 @@ class MyclabsEnumTransformer implements Transformer
         return TransformedType::create(
             $class,
             $name,
-            implode(' | ', $options)
+            implode(' | ', $options),
+            $this->compactor
         );
     }
 }

--- a/src/Transformers/SpatieEnumTransformer.php
+++ b/src/Transformers/SpatieEnumTransformer.php
@@ -4,13 +4,17 @@ namespace Spatie\TypeScriptTransformer\Transformers;
 
 use ReflectionClass;
 use Spatie\Enum\Enum;
+use Spatie\TypeScriptTransformer\Compactors\ConfigCompactor;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class SpatieEnumTransformer implements Transformer
 {
+    protected ConfigCompactor $compactor;
+
     public function __construct(protected TypeScriptTransformerConfig $config)
     {
+        $this->compactor = new ConfigCompactor($config);
     }
 
     public function transform(ReflectionClass $class, string $name): ?TransformedType
@@ -39,6 +43,7 @@ class SpatieEnumTransformer implements Transformer
             $class,
             $name,
             implode(', ', $options),
+            $this->compactor,
             keyword: 'enum'
         );
     }
@@ -56,7 +61,8 @@ class SpatieEnumTransformer implements Transformer
         return TransformedType::create(
             $class,
             $name,
-            implode(' | ', $options)
+            implode(' | ', $options),
+            $this->compactor
         );
     }
 }

--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -27,6 +27,10 @@ class TypeScriptTransformerConfig
 
     private ?string $formatter = null;
 
+    private array $compactorPrefixes = [];
+
+    private array $compactorSuffixes = [];
+
     private bool $transformToNativeEnums = false;
 
     private bool $nullToOptional = false;
@@ -85,6 +89,34 @@ class TypeScriptTransformerConfig
         return $this;
     }
 
+    /**
+     * @param string[]|string $prefixes
+     * @return $this
+     */
+    public function compactorPrefixes(array|string $prefixes): self
+    {
+        if (!is_array($prefixes)) {
+            $prefixes = [$prefixes];
+        }
+        $this->compactorPrefixes = $prefixes;
+
+        return $this;
+    }
+
+    /**
+     * @param string[]|string $suffixes
+     * @return $this
+     */
+    public function compactorSuffixes(array|string $suffixes): self
+    {
+        if (!is_array($suffixes)) {
+            $suffixes = [$suffixes];
+        }
+        $this->compactorSuffixes = $suffixes;
+
+        return $this;
+    }
+
     public function transformToNativeEnums(bool $transformToNativeEnums = true): self
     {
         $this->transformToNativeEnums = $transformToNativeEnums;
@@ -122,7 +154,7 @@ class TypeScriptTransformerConfig
 
     public function getWriter(): Writer
     {
-        return new $this->writer;
+        return new $this->writer($this);
     }
 
     public function getOutputFile(): string
@@ -165,6 +197,22 @@ class TypeScriptTransformerConfig
         }
 
         return new $this->formatter;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCompactorPrefixes(): array
+    {
+        return $this->compactorPrefixes ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCompactorSuffixes(): array
+    {
+        return $this->compactorSuffixes ?? [];
     }
 
     public function shouldTransformToNativeEnums(): bool

--- a/src/Writers/TypeDefinitionWriter.php
+++ b/src/Writers/TypeDefinitionWriter.php
@@ -3,11 +3,20 @@
 namespace Spatie\TypeScriptTransformer\Writers;
 
 use Spatie\TypeScriptTransformer\Actions\ReplaceSymbolsInCollectionAction;
+use Spatie\TypeScriptTransformer\Compactors\Compactor;
+use Spatie\TypeScriptTransformer\Compactors\ConfigCompactor;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
 class TypeDefinitionWriter implements Writer
 {
+    protected Compactor $compactor;
+
+    public function __construct(TypeScriptTransformerConfig $config) {
+        $this->compactor = new ConfigCompactor($config);
+    }
+
     public function format(TypesCollection $collection): string
     {
         (new ReplaceSymbolsInCollectionAction())->execute($collection);
@@ -18,6 +27,7 @@ class TypeDefinitionWriter implements Writer
 
         foreach ($namespaces as $namespace => $types) {
             asort($types);
+            $namespace = $this->compactor->compact($namespace);
 
             $output .= "declare namespace {$namespace} {".PHP_EOL;
 

--- a/tests/Fakes/FakeTransformedType.php
+++ b/tests/Fakes/FakeTransformedType.php
@@ -4,17 +4,19 @@ namespace Spatie\TypeScriptTransformer\Tests\Fakes;
 
 use Exception;
 use ReflectionClass;
+use Spatie\TypeScriptTransformer\Compactors\Compactor;
+use Spatie\TypeScriptTransformer\Compactors\IdentityCompactor;
 use Spatie\TypeScriptTransformer\Structures\MissingSymbolsCollection;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 
 class FakeTransformedType extends TransformedType
 {
-    public static function create(ReflectionClass $class, string $name, string $transformed, ?MissingSymbolsCollection $missingSymbols = null, bool $inline = false, string $keyword = 'type', bool $trailingSemicolon = true): TransformedType
+    public static function create(ReflectionClass $class, string $name, string $transformed, Compactor $compactor, ?MissingSymbolsCollection $missingSymbols = null, bool $inline = false, string $keyword = 'type', bool $trailingSemicolon = true): TransformedType
     {
         throw new Exception("Fake type");
     }
 
-    public static function createInline(ReflectionClass $class, string $transformed, ?MissingSymbolsCollection $missingSymbols = null): TransformedType
+    public static function createInline(ReflectionClass $class, string $transformed, Compactor $compactor, ?MissingSymbolsCollection $missingSymbols = null): TransformedType
     {
         throw new Exception("Fake type");
     }
@@ -27,6 +29,7 @@ class FakeTransformedType extends TransformedType
             FakeReflectionClass::create()->withName($name),
             $name,
             'fake-transformed',
+            new IdentityCompactor(),
             new MissingSymbolsCollection(),
             false
         );

--- a/tests/Fakes/FakeTypeScriptCollector.php
+++ b/tests/Fakes/FakeTypeScriptCollector.php
@@ -21,6 +21,7 @@ class FakeTypeScriptCollector extends Collector
             $class,
             $class->getShortName(),
             'fake-collected-class',
+            $this->compactor,
             new MissingSymbolsCollection(),
             false
         );

--- a/tests/Transformers/DtoTransformerTest.php
+++ b/tests/Transformers/DtoTransformerTest.php
@@ -161,3 +161,61 @@ it('transforms nullable properties to optional ones according to config', functi
 
     $this->assertMatchesSnapshot($type->transformed);
 });
+
+it('compacts namespaces', function () {
+    $reflectionClass = new ReflectionClass(Dto::class);
+    assertEquals(
+        'Dto',
+        (new DtoTransformer(
+            TypeScriptTransformerConfig::create()
+                ->compactorPrefixes([
+                    "Spatie.TypeScriptTransformer.Tests.FakeClasses.Integration"
+                ])
+        ))->transform(
+            $reflectionClass,
+            'Dto'
+        )->getTypeScriptName(true)
+    );
+
+    assertEquals(
+        'Integration.Dto',
+        (new DtoTransformer(
+            TypeScriptTransformerConfig::create()
+                ->compactorPrefixes([
+                    "Spatie.TypeScriptTransformer.Tests.FakeClasses"
+                ])
+        ))->transform(
+            $reflectionClass,
+            'Dto'
+        )->getTypeScriptName(true)
+    );
+    assertEquals(
+        'Integration.Dto',
+        (new DtoTransformer(
+            TypeScriptTransformerConfig::create()
+                ->compactorPrefixes([
+                    "Spatie.TypeScriptTransformer.Tests.RealClasses",
+                    "Spatie.TypeScriptTransformer.Tests.FakeClasses"
+                ])
+        ))->transform(
+            $reflectionClass,
+            'Dto'
+        )->getTypeScriptName(true)
+    );
+});
+it('compacts type names', function () {
+    $reflectionClass = new ReflectionClass(DtoWithChildren::class);
+    assertEquals(
+        'Dto',
+        (new DtoTransformer(
+            TypeScriptTransformerConfig::create()
+                ->compactorPrefixes("Spatie.TypeScriptTransformer.Tests.FakeClasses.Integration")
+                ->compactorSuffixes([
+                    'WithChildren'
+                ])
+        ))->transform(
+            $reflectionClass,
+            'DtoWithChildren'
+        )->getTypeScriptName(true)
+    );
+});

--- a/tests/TypeScriptTransformerConfigTest.php
+++ b/tests/TypeScriptTransformerConfigTest.php
@@ -68,3 +68,9 @@ it('can use a php dodumenter type in a class property replacer', function () {
         $config->getDefaultTypeReplacements()
     );
 });
+
+it('can handle string as compactor_prefixes parameter', function () {
+    $config = TypeScriptTransformerConfig::create()->compactorPrefixes('asdf.asdf');
+
+    assertEquals(['asdf.asdf'], $config->getCompactorPrefixes());
+});


### PR DESCRIPTION
**Problem:** 
- When using namespaced type definitions, it uses fully qualified type names, but they are long and repetitive, they can introduce a lot of noise into frontend code. But we do need them so types with the same name from different namespaces don't clash.
- When using data class name suffixes, they are repeated on every resulting typescript type definition. But you need them on the backend so that the class name doesn't clash with your e.g. database entity names.

**Solution:** introduce Compactors to remove redundant parts from type names and namespaces

**Example:** same entity in different bounded contexts: accounting and inventory

```php
<?php

namespace App\Data\Accounting;

use Spatie\TypeScriptTransformer\Attributes\TypeScript;

#[TypeScript]
class ProductData
{
    public function __construct(
        public int $acquisitionCost
    ) {
    }
}

```

```php
<?php

namespace App\Data\Inventory;

use Spatie\TypeScriptTransformer\Attributes\TypeScript;

#[TypeScript]
class ProductData
{
      public function __construct(
        public string $sku,
        public int $price
    ) {
    }
}

```

### Before Compactors:


```
$ artisan typescript:transform
+--------------------------------------------+---------------------------------+
| PHP class                                  | TypeScript entity               |
+--------------------------------------------+---------------------------------+
| App\Data\Accounting\ProductData            | App.Data.Accounting.ProductData |
| App\Data\Inventory\ProductData             | App.Data.Inventory.ProductData  |
+--------------------------------------------+---------------------------------+
```

```ts
declare namespace App.Data.Accounting {
    export type ProductData = {
        acquisitionCost: number;    
    };
}
declare namespace App.Data.Inventory {
    export type ProductData = {
        sku: string;
        price: number;    
    };
}
```

### With Compactors:

```php
    // in config/typescript-transformers.php
    'compactor' => [
        'prefixes' => ['App\\Data', 'App\\Enums'],
        'suffixes' => 'Data',
    ],
```
```
$ artisan typescript:transform
+--------------------------------------------+--------------------+
| PHP class                                  | TypeScript entity  |
+--------------------------------------------+--------------------+
| App\Data\Accounting\ProductData            | Accounting.Product |
| App\Data\Accounting\Inventory\ProductData  | Inventory.Product  |
+--------------------------------------------+--------------------+

```

```ts

declare namespace Accounting {
    export type Product = {
        acquisitionCost: number;
    };
}
declare namespace Inventory {
    export type Product = {
        sku: string;
        price: number;
    };
}

```

### Notes

Some things are still missing and it needs more testing.

What do you think?