### PR TITLE
Implement splitting types per file per namespace

### DIFF
--- a/src/Actions/FormatTypeScriptAction.php
+++ b/src/Actions/FormatTypeScriptAction.php
@@ -8,8 +8,10 @@ class FormatTypeScriptAction
 {
     protected TypeScriptTransformerConfig $config;
 
-    public function __construct(TypeScriptTransformerConfig $config)
-    {
+    public function __construct(
+        TypeScriptTransformerConfig $config,
+        protected string $outputFile
+    ) {
         $this->config = $config;
     }
 
@@ -21,6 +23,6 @@ class FormatTypeScriptAction
             return;
         }
 
-        $formatter->format($this->config->getOutputFile());
+        $formatter->format($this->outputFile);
     }
 }

--- a/src/Actions/PersistTypesCollectionAction.php
+++ b/src/Actions/PersistTypesCollectionAction.php
@@ -9,7 +9,7 @@ class PersistTypesCollectionAction
 {
     protected TypeScriptTransformerConfig $config;
 
-    public function __construct(TypeScriptTransformerConfig $config)
+    public function __construct(TypeScriptTransformerConfig $config, protected string $outputFile)
     {
         $this->config = $config;
     }
@@ -26,15 +26,15 @@ class PersistTypesCollectionAction
         );
 
         file_put_contents(
-            $this->config->getOutputFile(),
+            $this->outputFile,
             $writer->format($collection)
         );
     }
 
     protected function ensureOutputFileExists(): void
     {
-        if (! file_exists(pathinfo($this->config->getOutputFile(), PATHINFO_DIRNAME))) {
-            mkdir(pathinfo($this->config->getOutputFile(), PATHINFO_DIRNAME), 0755, true);
+        if (! file_exists(pathinfo($this->outputFile, PATHINFO_DIRNAME))) {
+            mkdir(pathinfo($this->outputFile, PATHINFO_DIRNAME), 0755, true);
         }
     }
 }

--- a/src/Actions/ResolveSplitTypesCollectionsAction.php
+++ b/src/Actions/ResolveSplitTypesCollectionsAction.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Actions;
+
+use Exception;
+use Generator;
+use ReflectionClass;
+use Spatie\TypeScriptTransformer\Exceptions\NoAutoDiscoverTypesPathsDefined;
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
+use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+use Symfony\Component\Finder\Finder;
+
+class ResolveSplitTypesCollectionsAction
+{
+    protected Finder $finder;
+
+    /** @var \Spatie\TypeScriptTransformer\Collectors\Collector[] */
+    protected array $collectors;
+
+    protected TypeScriptTransformerConfig $config;
+
+    public function __construct(Finder $finder, TypeScriptTransformerConfig $config)
+    {
+        $this->finder = $finder;
+
+        $this->config = $config;
+
+        $this->collectors = $config->getCollectors();
+    }
+
+    /**
+     * @return TypesCollection[]
+     * @throws NoAutoDiscoverTypesPathsDefined
+     */
+    public function execute(): array
+    {
+        $collections = [];
+
+        $paths = $this->config->getAutoDiscoverTypesPaths();
+
+        if (empty($paths)) {
+            throw NoAutoDiscoverTypesPathsDefined::create();
+        }
+
+        foreach ($this->resolveIterator($paths) as $class) {
+            $transformedType = $this->resolveTransformedType($class);
+
+            if ($transformedType === null) {
+                continue;
+            }
+            $namespace = implode('/', $transformedType->getNamespaceSegments());
+            if (!isset($collections[$namespace])) {
+                $collections[$namespace] = new TypesCollection();
+            }
+            $collections[$namespace][] = $transformedType;
+        }
+
+        return $collections;
+    }
+
+    protected function resolveIterator(array $paths): Generator
+    {
+        $paths = array_map(
+            fn (string $path) => is_dir($path) ? $path : dirname($path),
+            $paths
+        );
+
+        foreach ($this->finder->in($paths) as $fileInfo) {
+            try {
+                $classes = (new ResolveClassesInPhpFileAction())->execute($fileInfo);
+
+                foreach ($classes as $name) {
+                    yield $name => new ReflectionClass($name);
+                }
+            } catch (Exception $exception) {
+            }
+        }
+    }
+
+    protected function resolveTransformedType(ReflectionClass $class): ?TransformedType
+    {
+        foreach ($this->collectors as $collector) {
+            $transformedType = $collector->getTransformedType($class);
+
+            if ($transformedType !== null) {
+                return $transformedType;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -31,6 +31,8 @@ class TypeScriptTransformerConfig
 
     private bool $nullToOptional = false;
 
+    private string|null $splitModulesBaseDir = null;
+
     public static function create(): self
     {
         return new self();
@@ -95,6 +97,13 @@ class TypeScriptTransformerConfig
     public function nullToOptional(bool $nullToOptional = false): self
     {
         $this->nullToOptional = $nullToOptional;
+
+        return $this;
+    }
+
+    public function splitModulesBaseDir(string|null $splitModules = null): self
+    {
+        $this->splitModulesBaseDir = $splitModules;
 
         return $this;
     }
@@ -175,5 +184,10 @@ class TypeScriptTransformerConfig
     public function shouldConsiderNullAsOptional(): bool
     {
         return $this->nullToOptional;
+    }
+
+    public function getSplitModulesBaseDir(): string|null
+    {
+        return $this->splitModulesBaseDir;
     }
 }

--- a/tests/Actions/FormatTypeScriptActionTest.php
+++ b/tests/Actions/FormatTypeScriptActionTest.php
@@ -21,10 +21,13 @@ it('can format an generated file', function () {
         }
     };
 
-    $action = new FormatTypeScriptAction(
-        TypeScriptTransformerConfig::create()
+    $config = TypeScriptTransformerConfig::create()
         ->formatter($formatter::class)
-        ->outputFile($this->outputFile)
+        ->outputFile($this->outputFile);
+
+    $action = new FormatTypeScriptAction(
+        $config,
+        $config->getOutputFile()
     );
 
     file_put_contents(
@@ -38,8 +41,11 @@ it('can format an generated file', function () {
 });
 
 it('can disable formatting', function () {
+    $config = TypeScriptTransformerConfig::create()->outputFile($this->outputFile);
+
     $action = new FormatTypeScriptAction(
-        TypeScriptTransformerConfig::create()->outputFile($this->outputFile)
+        $config,
+        $config->getOutputFile()
     );
 
     file_put_contents(

--- a/tests/Actions/PersistTypesCollectionActionTest.php
+++ b/tests/Actions/PersistTypesCollectionActionTest.php
@@ -11,11 +11,13 @@ use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 beforeEach(function () {
     $this->temporaryDirectory = (new TemporaryDirectory())->create();
 
-    $this->action = new PersistTypesCollectionAction(
-        TypeScriptTransformerConfig::create()
+    $config = TypeScriptTransformerConfig::create()
         ->autoDiscoverTypes(__DIR__ . '/../FakeClasses')
         ->transformers([MyclabsEnumTransformer::class])
-        ->outputFile($this->temporaryDirectory->path('types.d.ts'))
+        ->outputFile($this->temporaryDirectory->path('types.d.ts'));
+    $this->action = new PersistTypesCollectionAction(
+        $config,
+        $config->getOutputFile()
     );
 });
 

--- a/tests/Actions/ResolveSplitTypesCollectionsActionTest.php
+++ b/tests/Actions/ResolveSplitTypesCollectionsActionTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use Spatie\TypeScriptTransformer\Actions\ResolveSplitTypesCollectionsAction;
+use Spatie\TypeScriptTransformer\Structures\TypesCollection;
+use function PHPUnit\Framework\assertArrayHasKey;
+use function PHPUnit\Framework\assertContains;
+use function PHPUnit\Framework\assertCount;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertTrue;
+use Spatie\TypeScriptTransformer\Actions\ResolveTypesCollectionAction;
+use Spatie\TypeScriptTransformer\Collectors\DefaultCollector;
+use Spatie\TypeScriptTransformer\Exceptions\NoAutoDiscoverTypesPathsDefined;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Enum\RegularEnum;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Enum\TypeScriptEnum;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Enum\TypeScriptEnumWithCustomTransformer;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Enum\TypeScriptEnumWithName;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Integration\Dto;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Integration\DtoWithChildren;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Integration\Enum;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Integration\LevelUp\YetAnotherDto;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Integration\OtherDto;
+use Spatie\TypeScriptTransformer\Tests\FakeClasses\Integration\OtherDtoCollection;
+use Spatie\TypeScriptTransformer\Tests\Fakes\FakeTypeScriptCollector;
+use Spatie\TypeScriptTransformer\Transformers\DtoTransformer;
+use Spatie\TypeScriptTransformer\Transformers\MyclabsEnumTransformer;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+use Symfony\Component\Finder\Finder;
+
+beforeEach(function () {
+    $this->action = new ResolveSplitTypesCollectionsAction(
+        new Finder(),
+        TypeScriptTransformerConfig::create()
+            ->autoDiscoverTypes(__DIR__ . '/../FakeClasses/Enum')
+            ->transformers([MyclabsEnumTransformer::class])
+            ->collectors([DefaultCollector::class])
+            ->splitModulesBaseDir('data')
+    );
+});
+
+it('will construct the type collections correctly', function () {
+    $typesCollections = $this->action->execute();
+
+    assertCount(1, $typesCollections);
+});
+
+it('will check if auto discover types paths are defined', function () {
+    $this->expectException(NoAutoDiscoverTypesPathsDefined::class);
+
+    $action = new ResolveSplitTypesCollectionsAction(
+        new Finder(),
+        TypeScriptTransformerConfig::create()
+    );
+
+    $action->execute();
+});
+
+it('parses a typescript enum correctly', function () {
+    $collections = $this->action->execute();
+    $type = $collections[array_key_first($collections)][TypeScriptEnum::class];
+
+    assertEquals(new ReflectionClass(new TypeScriptEnum('js')), $type->reflection);
+    assertEquals('TypeScriptEnum', $type->name);
+    assertEquals("'js'", $type->transformed);
+    assertTrue($type->missingSymbols->isEmpty());
+});
+
+it('parses a typescript enum with name correctly', function () {
+    $collections = $this->action->execute();
+    $type = $collections[array_key_first($collections)][TypeScriptEnumWithName::class];
+
+    assertCount(1, $collections);
+    assertEquals(new ReflectionClass(new TypeScriptEnumWithName('js')), $type->reflection);
+    assertEquals('EnumWithName', $type->name);
+    assertEquals("'js'", $type->transformed);
+    assertTrue($type->missingSymbols->isEmpty());
+});
+
+it('parses a typescript enum with custom transformer correctly', function () {
+    $collections = $this->action->execute();
+    $type = $collections[array_key_first($collections)][TypeScriptEnumWithCustomTransformer::class];
+
+    assertEquals(new ReflectionClass(new TypeScriptEnumWithCustomTransformer('js')), $type->reflection);
+    assertEquals('TypeScriptEnumWithCustomTransformer', $type->name);
+    assertEquals("fake", $type->transformed);
+    assertTrue($type->missingSymbols->isEmpty());
+});
+
+it('can parse multiple directories', function () {
+    $this->action = new ResolveSplitTypesCollectionsAction(
+        new Finder(),
+        TypeScriptTransformerConfig::create()
+        ->autoDiscoverTypes(
+            __DIR__ . '/../FakeClasses/Enum/',
+            __DIR__ . '/../FakeClasses/Integration/'
+        )
+        ->transformers([MyclabsEnumTransformer::class, DtoTransformer::class])
+        ->collectors([DefaultCollector::class])
+        ->outputFile('types.d.ts')
+    );
+
+    $collections = $this->action->execute();
+
+    $types = new TypesCollection();
+    foreach ($collections as $collection) {
+        foreach ($collection as $type) {
+            $types[] = $type;
+        }
+    }
+
+    assertCount(3, $collections);
+    assertArrayHasKey("Spatie/TypeScriptTransformer/Tests/FakeClasses/Enum", $collections);
+    assertArrayHasKey("Spatie/TypeScriptTransformer/Tests/FakeClasses/Integration", $collections);
+    assertArrayHasKey("Spatie/TypeScriptTransformer/Tests/FakeClasses/Integration/LevelUp", $collections);
+    assertCount(9, $types);
+
+    assertArrayHasKey(TypeScriptEnum::class, $types);
+    assertArrayHasKey(TypeScriptEnumWithCustomTransformer::class, $types);
+    assertArrayHasKey(TypeScriptEnumWithName::class, $types);
+
+    assertArrayHasKey(Dto::class, $types);
+    assertArrayHasKey(DtoWithChildren::class, $types);
+    assertArrayHasKey(Enum::class, $types);
+    assertArrayHasKey(OtherDto::class, $types);
+    assertArrayHasKey(OtherDtoCollection::class, $types);
+    assertArrayHasKey(YetAnotherDto::class, $types);
+});
+
+it('can add a collector for types', function () {
+    $this->action = new ResolveSplitTypesCollectionsAction(
+        new Finder(),
+        TypeScriptTransformerConfig::create()
+        ->autoDiscoverTypes(__DIR__ . '/../FakeClasses/Enum')
+        ->collectors([FakeTypeScriptCollector::class])
+        ->outputFile('types.d.ts')
+    );
+
+    $collections = $this->action->execute();
+    $types = $collections[array_key_first($collections)];
+
+    assertCount(1, $collections);
+    assertCount(4, $types);
+    assertArrayHasKey(RegularEnum::class, $types);
+    assertArrayHasKey(TypeScriptEnum::class, $types);
+    assertArrayHasKey(TypeScriptEnumWithCustomTransformer::class, $types);
+    assertArrayHasKey(TypeScriptEnumWithName::class, $types);
+});


### PR DESCRIPTION
**Problem:** When you have to use `ModuleWriter` (e.g. to get usable enums instead of only type definitions), you can't have types with the same base name but from different PHP namespaces.

**Solution:** Group code per namespace and output it in a corresponding directory structure, where the last part of namespace is used to name the output `.ts` file for a group

Introduces new config option:

```php
    'split_modules_base_dir' => resource_path('ts/dto/'),
```

If it is set, uses an alternative strategy for bundling the code that puts types from every namespace into their own file, with directory structure mimicking the namespace parts. 

Otherwise puts all code into `output_file` as usual.


### Notes

Works well with #104 for my use case producing very simple output directory structure, but definitely needs more testing and probably some redesign.