### PR TITLE
fix: escape backslashes and quotes in enum string values

### DIFF
--- a/src/TypeScriptNodes/TypeScriptEnum.php
+++ b/src/TypeScriptNodes/TypeScriptEnum.php
@@ -25,7 +25,7 @@ class TypeScriptEnum implements TypeScriptNamedNode, TypeScriptNode
 
             $output .= match (true) {
                 is_int($case['value']) => "{$case['name']} = {$case['value']},",
-                is_string($case['value']) => "{$case['name']} = '{$case['value']}',",
+                is_string($case['value']) => "{$case['name']} = '" . addcslashes($case['value'], "\\'") . "',",
                 default => "{$case['name']},",
             };
 

--- a/tests/TypeScript/TypeScriptEnumTest.php
+++ b/tests/TypeScript/TypeScriptEnumTest.php
@@ -67,4 +67,30 @@ enum Enum {
 TS
     ,
     ];
+
+    yield 'string enum with backslashes' => [
+        'cases' => [
+            ['name' => 'User', 'value' => 'App\\Models\\User'],
+            ['name' => 'Post', 'value' => 'App\\Models\\Post'],
+        ],
+        'expected' => <<<TS
+enum Enum {
+    User = 'App\\\\Models\\\\User',
+    Post = 'App\\\\Models\\\\Post',
+}
+TS
+    ,
+    ];
+
+    yield 'string enum with single quotes' => [
+        'cases' => [
+            ['name' => 'Greeting', 'value' => "it's"],
+        ],
+        'expected' => <<<TS
+enum Enum {
+    Greeting = 'it\\'s',
+}
+TS
+    ,
+    ];
 });


### PR DESCRIPTION
## Summary
- `TypeScriptEnum::write()` now escapes backslashes and single quotes in string-backed enum values using `addcslashes`
- Previously, values like `App\Models\User` produced invalid TypeScript (`'App\Models\User'` instead of `'App\\Models\\User'`)
- Added test cases for backslashes and single quotes in enum string values

## Test plan
- [x] Existing enum tests still pass
- [x] New test cases fail without the fix, pass with it