### PR TITLE
feat: make AttributedClassTransformer extensible via attributeClass()

### DIFF
--- a/src/Transformers/AttributedClassTransformer.php
+++ b/src/Transformers/AttributedClassTransformer.php
@@ -10,9 +10,14 @@ use Spatie\TypeScriptTransformer\Transformed\Untransformable;
 
 class AttributedClassTransformer extends ClassTransformer
 {
+    protected function attributeClass(): string
+    {
+        return TypeScript::class;
+    }
+
     protected function shouldTransform(PhpClassNode $phpClassNode): bool
     {
-        return count($phpClassNode->getAttributes(TypeScript::class)) > 0;
+        return count($phpClassNode->getAttributes($this->attributeClass())) > 0;
     }
 
     public function transform(PhpClassNode $phpClassNode, TransformationContext $context): Transformed|Untransformable
@@ -23,8 +28,7 @@ class AttributedClassTransformer extends ClassTransformer
             return $transformed;
         }
 
-        /** @var TypeScript $attribute */
-        $attribute = $phpClassNode->getAttributes(TypeScript::class)[0]->getRawArguments();
+        $attribute = $phpClassNode->getAttributes($this->attributeClass())[0]->getRawArguments();
 
         if (($attribute['name'] ?? null) !== null) {
             $transformed->nameAs($attribute['name']);


### PR DESCRIPTION
## Summary

`AttributedClassTransformer` had `TypeScript::class` hardcoded in two places, making it impossible to subclass and use a custom attribute without duplicating the entire transformer.

This PR extracts it into a single protected `attributeClass()` method, so users can extend the transformer for their own attribute:

```php
class FrontEndAttributedClassTransformer extends AttributedClassTransformer
{
    protected function attributeClass(): string
    {
        return FrontEnd::class;
    }
}
```

## Changes

- Added `protected function attributeClass(): string` to `AttributedClassTransformer`, defaulting to `TypeScript::class`
- Replaced both hardcoded `TypeScript::class` references in `shouldTransform()` and `transform()` with `$this->attributeClass()`
- Removed the now-inaccurate `@var TypeScript` docblock on the attribute variable