### PR TITLE
fix: escape PHP binary path when starting watcher worker

### DIFF
--- a/src/Runners/Runner.php
+++ b/src/Runners/Runner.php
@@ -153,7 +153,7 @@ class Runner
         $phpBinary = (new PhpExecutableFinder())->find();
         $command = ($this->workerCommand)(true);
 
-        $process = Process::fromShellCommandline("$phpBinary $command");
+        $process = Process::fromShellCommandline(escapeshellarg($phpBinary)." $command");
         $process->start();
 
         return $process;


### PR DESCRIPTION
On macOS via Laravel Herd, `PhpExecutableFinder::find()` returns `/Users/<me>/Library/Application Support/Herd/bin/php84`. The space breaks `Process::fromShellCommandline("$phpBinary $command")`:

```
sh: /Users/<me>/Library/Application: No such file or directory
```

The watcher then loops on `Worker failed to start. Waiting for application to be fixed...`.

Wrapping `$phpBinary` in `escapeshellarg()` fixes it without changing the `workerCommand` contract.