### PR TITLE
Allow generic types to work with co/contravariant templates

### DIFF
--- a/src/TypeResolvers/DocTypeResolver.php
+++ b/src/TypeResolvers/DocTypeResolver.php
@@ -54,7 +54,13 @@ class DocTypeResolver
 
         $templates = [];
 
-        foreach ($parsed->getTemplateTagValues() as $templateTag) {
+        $templateTags = [
+            ...$parsed->getTemplateTagValues("@template"),
+            ...$parsed->getTemplateTagValues("@template-covariant"),
+            ...$parsed->getTemplateTagValues("@template-contravariant"),
+        ];
+
+        foreach ($templateTags as $templateTag) {
             $templates[] = $templateTag->name;
         }
 

--- a/src/TypeResolvers/DocTypeResolver.php
+++ b/src/TypeResolvers/DocTypeResolver.php
@@ -55,9 +55,9 @@ class DocTypeResolver
         $templates = [];
 
         $templateTags = [
-            ...$parsed->getTemplateTagValues("@template"),
-            ...$parsed->getTemplateTagValues("@template-covariant"),
-            ...$parsed->getTemplateTagValues("@template-contravariant"),
+            ...$parsed->getTemplateTagValues('@template'),
+            ...$parsed->getTemplateTagValues('@template-covariant'),
+            ...$parsed->getTemplateTagValues('@template-contravariant'),
         ];
 
         foreach ($templateTags as $templateTag) {

--- a/tests/Actions/DiscoverTypesActionTest.php
+++ b/tests/Actions/DiscoverTypesActionTest.php
@@ -6,6 +6,8 @@ use Spatie\TypeScriptTransformer\PhpNodes\PhpEnumNode;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\ComplexAttribute;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\EmptyEnum;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericClass;
+use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericContravariantClass;
+use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericCovariantClass;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\HiddenAttributedClass;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\IntBackedEnum;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\OptionalAttributedClass;
@@ -35,6 +37,8 @@ it('can discover types', function () {
         new PhpClassNode(new ReflectionClass(ComplexAttribute::class)),
         new PhpEnumNode(new ReflectionEnum(EmptyEnum::class)),
         new PhpClassNode(new ReflectionClass(GenericClass::class)),
+        new PhpClassNode(new ReflectionClass(GenericContravariantClass::class)),
+        new PhpClassNode(new ReflectionClass(GenericCovariantClass::class)),
         new PhpClassNode(new ReflectionClass(HiddenAttributedClass::class)),
         new PhpEnumNode(new ReflectionEnum(IntBackedEnum::class)),
         new PhpClassNode(new ReflectionClass(OptionalAttributedClass::class)),

--- a/tests/Fakes/TypesToProvide/GenericContravariantClass.php
+++ b/tests/Fakes/TypesToProvide/GenericContravariantClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide;
+
+/**
+ * @template-contravariant T
+ */
+class GenericContravariantClass
+{
+    /**
+     * @param array<T> $data
+     */
+    public function __construct(
+        public int $page = 1,
+        public array $data = [],
+    ) {
+    }
+}

--- a/tests/Fakes/TypesToProvide/GenericCovariantClass.php
+++ b/tests/Fakes/TypesToProvide/GenericCovariantClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide;
+
+/**
+ * @template-covariant T
+ */
+class GenericCovariantClass
+{
+    /**
+     * @param array<T> $data
+     */
+    public function __construct(
+        public int $page = 1,
+        public array $data = [],
+    ) {
+    }
+}

--- a/tests/Transformers/ClassTransformerTest.php
+++ b/tests/Transformers/ClassTransformerTest.php
@@ -11,6 +11,8 @@ use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpPropertyNode;
 use Spatie\TypeScriptTransformer\References\PhpClassReference;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericClass;
+use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericContravariantClass;
+use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericCovariantClass;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\ReadonlyClass;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\SimpleClass;
 use Spatie\TypeScriptTransformer\Tests\TestSupport\AllClassTransformer;
@@ -352,6 +354,52 @@ it('can transform a class with template generics', function () {
         new TypeScriptAlias(
             new TypeScriptGeneric(
                 new TypeScriptIdentifier('GenericClass'),
+                [new TypeScriptGenericTypeParameter(new TypeScriptIdentifier('T'))]
+            ),
+            new TypeScriptObject([
+                new TypeScriptProperty(
+                    new TypeScriptIdentifier('page'),
+                    new TypeScriptNumber()
+                ),
+                new TypeScriptProperty(
+                    new TypeScriptIdentifier('data'),
+                    new TypeScriptArray([new TypeScriptIdentifier('T')])
+                ),
+            ])
+        )
+    );
+});
+
+it('can transform a class with template-covariant generics', function () {
+    $transformed = transformSingle(GenericCovariantClass::class);
+
+    expect($transformed->getNode())->toEqual(
+        new TypeScriptAlias(
+            new TypeScriptGeneric(
+                new TypeScriptIdentifier('GenericCovariantClass'),
+                [new TypeScriptGenericTypeParameter(new TypeScriptIdentifier('T'))]
+            ),
+            new TypeScriptObject([
+                new TypeScriptProperty(
+                    new TypeScriptIdentifier('page'),
+                    new TypeScriptNumber()
+                ),
+                new TypeScriptProperty(
+                    new TypeScriptIdentifier('data'),
+                    new TypeScriptArray([new TypeScriptIdentifier('T')])
+                ),
+            ])
+        )
+    );
+});
+
+it('can transform a class with template-contravariant generics', function () {
+    $transformed = transformSingle(GenericContravariantClass::class);
+
+    expect($transformed->getNode())->toEqual(
+        new TypeScriptAlias(
+            new TypeScriptGeneric(
+                new TypeScriptIdentifier('GenericContravariantClass'),
                 [new TypeScriptGenericTypeParameter(new TypeScriptIdentifier('T'))]
             ),
             new TypeScriptObject([

--- a/tests/TypeProviders/TransformerTypesProviderTest.php
+++ b/tests/TypeProviders/TransformerTypesProviderTest.php
@@ -38,7 +38,7 @@ function getTestProvidedTypes(
 it('will find types and takes attributes into account', function () {
     $collection = getTestProvidedTypes();
 
-    expect($collection)->toHaveCount(11);
+    expect($collection)->toHaveCount(13);
 
     $typesToCheck = array_filter(
         iterator_to_array($collection),


### PR DESCRIPTION
`getTemplateTagValues()` defaults it's name parameter to `"@template"`, this commit explicitly specifies that, and adds `@template-covariant` and `@template-contravariant`