### PR TITLE
Add JSON_UNESCAPED_SLASHES to json_encode on TypeScriptLiteral

### DIFF
--- a/src/TypeScriptNodes/TypeScriptLiteral.php
+++ b/src/TypeScriptNodes/TypeScriptLiteral.php
@@ -12,6 +12,6 @@ class TypeScriptLiteral implements TypeScriptNode
 
     public function write(WritingContext $context): string
     {
-        return json_encode($this->value);
+        return json_encode($this->value, JSON_UNESCAPED_SLASHES);
     }
 }

--- a/tests/TypeScript/TypeScriptLiteralTest.php
+++ b/tests/TypeScript/TypeScriptLiteralTest.php
@@ -12,4 +12,5 @@ it('can write literal values', function (int|string|bool $value, string $expecte
     yield 'int' => [42, '42'];
     yield 'true' => [true, 'true'];
     yield 'false' => [false, 'false'];
+    yield 'no escaped slashes' => ['image/png', '"image/png"'];
 });


### PR DESCRIPTION
I don't believe we need to escape slashes when writing TypeScriptLiteral strings.


Example before:

```ts
export type ImageFormat =
                | 'image\/png'
                | 'image\/webp';
```

Example after:

```ts
export type ImageFormat =
                | 'image/png'
                | 'image/webp';
```

As far as I know, this wouldn't break existing code.