### PR TITLE
Re-deduplicate nested nodes after visitor mutations

### DIFF
--- a/src/TypeScriptNodes/Concerns/UniqueTypeScriptNodes.php
+++ b/src/TypeScriptNodes/Concerns/UniqueTypeScriptNodes.php
@@ -20,4 +20,5 @@ trait UniqueTypeScriptNodes
 
         return $unique;
     }
+
 }

--- a/src/TypeScriptNodes/TypeScriptArray.php
+++ b/src/TypeScriptNodes/TypeScriptArray.php
@@ -6,7 +6,7 @@ use Spatie\TypeScriptTransformer\Attributes\NodeVisitable;
 use Spatie\TypeScriptTransformer\Data\WritingContext;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\UniqueTypeScriptNodes;
 
-class TypeScriptArray implements TypeScriptNode
+class TypeScriptArray implements TypeScriptNode, TypeScriptDeduplicableNode
 {
     use UniqueTypeScriptNodes;
 
@@ -17,6 +17,11 @@ class TypeScriptArray implements TypeScriptNode
         #[NodeVisitable]
         public array $types
     ) {
+        $this->deduplicateNodes();
+    }
+
+    public function deduplicateNodes(): void
+    {
         $this->types = $this->uniqueNodes($this->types);
     }
 

--- a/src/TypeScriptNodes/TypeScriptDeduplicableNode.php
+++ b/src/TypeScriptNodes/TypeScriptDeduplicableNode.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\TypeScriptNodes;
+
+interface TypeScriptDeduplicableNode
+{
+    public function deduplicateNodes(): void;
+}

--- a/src/TypeScriptNodes/TypeScriptIntersection.php
+++ b/src/TypeScriptNodes/TypeScriptIntersection.php
@@ -6,7 +6,7 @@ use Spatie\TypeScriptTransformer\Attributes\NodeVisitable;
 use Spatie\TypeScriptTransformer\Data\WritingContext;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\UniqueTypeScriptNodes;
 
-class TypeScriptIntersection implements TypeScriptNode
+class TypeScriptIntersection implements TypeScriptNode, TypeScriptDeduplicableNode
 {
     use UniqueTypeScriptNodes;
 
@@ -17,6 +17,11 @@ class TypeScriptIntersection implements TypeScriptNode
         #[NodeVisitable]
         public array $types,
     ) {
+        $this->deduplicateNodes();
+    }
+
+    public function deduplicateNodes(): void
+    {
         $this->types = $this->uniqueNodes($this->types);
     }
 

--- a/src/TypeScriptNodes/TypeScriptUnion.php
+++ b/src/TypeScriptNodes/TypeScriptUnion.php
@@ -7,7 +7,7 @@ use Spatie\TypeScriptTransformer\Attributes\NodeVisitable;
 use Spatie\TypeScriptTransformer\Data\WritingContext;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\UniqueTypeScriptNodes;
 
-class TypeScriptUnion implements TypeScriptNode
+class TypeScriptUnion implements TypeScriptNode, TypeScriptDeduplicableNode
 {
     use UniqueTypeScriptNodes;
 
@@ -18,6 +18,11 @@ class TypeScriptUnion implements TypeScriptNode
         #[NodeVisitable]
         public array $types,
     ) {
+        $this->deduplicateNodes();
+    }
+
+    public function deduplicateNodes(): void
+    {
         $this->types = $this->uniqueNodes($this->types);
     }
 

--- a/src/Visitor/Visitor.php
+++ b/src/Visitor/Visitor.php
@@ -4,6 +4,7 @@ namespace Spatie\TypeScriptTransformer\Visitor;
 
 use Closure;
 use Spatie\TypeScriptTransformer\TypeScriptNodeRegistry;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptDeduplicableNode;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptNode;
 
 class Visitor
@@ -91,6 +92,10 @@ class Visitor
             $filtered = array_filter($value);
 
             $node->$propertyName = $isList ? array_values($filtered) : $filtered;
+        }
+
+        if ($node instanceof TypeScriptDeduplicableNode) {
+            $node->deduplicateNodes();
         }
 
         foreach ($this->closures as $closure) {

--- a/tests/ClassPropertyProcessors/FixArrayLikeStructuresClassPropertyProcessorTest.php
+++ b/tests/ClassPropertyProcessors/FixArrayLikeStructuresClassPropertyProcessorTest.php
@@ -159,6 +159,9 @@ it('replaces array like classes', function (
         public Collection $too_much_types_collection;
 
         public Collection $no_annotation_collection;
+
+        /** @var Collection<int, string>|string[] */
+        public array $duplicated_array_in_union;
     };
 
     $object = transformSingle($class)->getNode()->type;
@@ -253,5 +256,12 @@ it('replaces array like classes', function (
     yield 'no annotation collection' => [
         'no_annotation_collection',
         new TypeScriptReference(new ClassStringReference(Collection::class)),
+    ];
+
+    yield 'duplicated array in union' => [
+        'duplicated_array_in_union',
+        new TypeScriptUnion([
+            new TypeScriptArray([new TypeScriptString()]),
+        ]),
     ];
 });

--- a/tests/Visitor/VisitorTest.php
+++ b/tests/Visitor/VisitorTest.php
@@ -88,6 +88,23 @@ it('can replace a single node in an iterateable', function () {
     expect($unionNode->types)->toEqual([$stringNode, new TypeScriptBoolean()]);
 });
 
+it('deduplicates nested nodes after visiting a deduplicable node', function () {
+    $unionNode = new TypeScriptUnion([
+        new TypeScriptString(),
+        new TypeScriptNumber(),
+    ]);
+
+    Visitor::create()
+        ->before(function (TypeScriptNode $node) {
+            if ($node instanceof TypeScriptNumber) {
+                return VisitorOperation::replace(new TypeScriptString());
+            }
+        })
+        ->execute($unionNode);
+
+    expect($unionNode->types)->toEqual([new TypeScriptString()]);
+});
+
 it('will execute a before and after closure correctly', function () {
     $rootNode = new TypeScriptUnion([
         new TypeScriptString(),


### PR DESCRIPTION
## Summary

Fixes #137. When `FixArrayLikeStructuresClassPropertyProcessor` replaces a `Collection<int, string>` inside a union that already contains the equivalent `string[]`, the output ends up as `string[] | string[]`. The constructor-time dedup on `TypeScriptUnion` runs once and cannot catch duplicates introduced by later visitor mutations.

## Approach

- Introduces a `TypeScriptDeduplicableNode` interface (`deduplicateNodes(): void`).
- Implemented by `TypeScriptUnion`, `TypeScriptIntersection`, and `TypeScriptArray`. Each class defines its own `deduplicateNodes()` and its constructor calls it.
- The `Visitor` calls `deduplicateNodes()` on the current node after visiting its children, so any Replace/Remove that introduces duplicates is cleaned up automatically without each processor needing to know.
- Added a regression case to `FixArrayLikeStructuresClassPropertyProcessorTest` and a small `VisitorTest` that exercises the dedup-after-traversal behavior directly.