### PR TITLE
Centralize TS literal output and fix escape bugs

### DIFF
--- a/src/TypeScriptNodes/Concerns/OutputsTypeScriptLiteral.php
+++ b/src/TypeScriptNodes/Concerns/OutputsTypeScriptLiteral.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns;
+
+trait OutputsTypeScriptLiteral
+{
+    protected function outputLiteral(int|string|float|bool|null $value): string
+    {
+        if (is_string($value)) {
+            $escaped = strtr($value, [
+                '\\' => '\\\\',
+                "'" => "\\'",
+                "\n" => '\\n',
+                "\r" => '\\r',
+                "\t" => '\\t',
+            ]);
+
+            return "'{$escaped}'";
+        }
+
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+}

--- a/src/TypeScriptNodes/TypeScriptEnum.php
+++ b/src/TypeScriptNodes/TypeScriptEnum.php
@@ -3,9 +3,12 @@
 namespace Spatie\TypeScriptTransformer\TypeScriptNodes;
 
 use Spatie\TypeScriptTransformer\Data\WritingContext;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\OutputsTypeScriptLiteral;
 
 class TypeScriptEnum implements TypeScriptNamedNode, TypeScriptNode
 {
+    use OutputsTypeScriptLiteral;
+
     /**
      * @param string $name
      * @param array<int, array{name: string, value: string|int|null}> $cases
@@ -25,7 +28,7 @@ class TypeScriptEnum implements TypeScriptNamedNode, TypeScriptNode
 
             $output .= match (true) {
                 is_int($case['value']) => "{$case['name']} = {$case['value']},",
-                is_string($case['value']) => "{$case['name']} = '{$case['value']}',",
+                is_string($case['value']) => "{$case['name']} = {$this->outputLiteral($case['value'])},",
                 default => "{$case['name']},",
             };
 

--- a/src/TypeScriptNodes/TypeScriptIdentifier.php
+++ b/src/TypeScriptNodes/TypeScriptIdentifier.php
@@ -3,9 +3,12 @@
 namespace Spatie\TypeScriptTransformer\TypeScriptNodes;
 
 use Spatie\TypeScriptTransformer\Data\WritingContext;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\OutputsTypeScriptLiteral;
 
 class TypeScriptIdentifier implements TypeScriptNamedNode, TypeScriptNode
 {
+    use OutputsTypeScriptLiteral;
+
     public function __construct(
         public string $name,
     ) {
@@ -13,7 +16,9 @@ class TypeScriptIdentifier implements TypeScriptNamedNode, TypeScriptNode
 
     public function write(WritingContext $context): string
     {
-        return $this->isValidIdentifier($this->name) ? $this->name : "'$this->name'";
+        return $this->isValidIdentifier($this->name)
+            ? $this->name
+            : $this->outputLiteral($this->name);
     }
 
     private function isValidIdentifier(string $name): bool

--- a/src/TypeScriptNodes/TypeScriptImport.php
+++ b/src/TypeScriptNodes/TypeScriptImport.php
@@ -3,9 +3,12 @@
 namespace Spatie\TypeScriptTransformer\TypeScriptNodes;
 
 use Spatie\TypeScriptTransformer\Data\WritingContext;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\OutputsTypeScriptLiteral;
 
 class TypeScriptImport implements TypeScriptNode
 {
+    use OutputsTypeScriptLiteral;
+
     /**
      * @param  array<array{name: string, alias?: ?string}>  $segments
      */
@@ -28,6 +31,6 @@ class TypeScriptImport implements TypeScriptNode
             $this->segments,
         ));
 
-        return "import { {$segments} } from '{$this->path}';";
+        return "import { {$segments} } from {$this->outputLiteral($this->path)};";
     }
 }

--- a/src/TypeScriptNodes/TypeScriptLiteral.php
+++ b/src/TypeScriptNodes/TypeScriptLiteral.php
@@ -3,15 +3,18 @@
 namespace Spatie\TypeScriptTransformer\TypeScriptNodes;
 
 use Spatie\TypeScriptTransformer\Data\WritingContext;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\OutputsTypeScriptLiteral;
 
 class TypeScriptLiteral implements TypeScriptNode
 {
-    public function __construct(public int|string|bool $value)
+    use OutputsTypeScriptLiteral;
+
+    public function __construct(public int|string|float|bool|null $value)
     {
     }
 
     public function write(WritingContext $context): string
     {
-        return json_encode($this->value);
+        return $this->outputLiteral($this->value);
     }
 }

--- a/src/TypeScriptNodes/TypeScriptParameter.php
+++ b/src/TypeScriptNodes/TypeScriptParameter.php
@@ -4,9 +4,12 @@ namespace Spatie\TypeScriptTransformer\TypeScriptNodes;
 
 use Spatie\TypeScriptTransformer\Attributes\NodeVisitable;
 use Spatie\TypeScriptTransformer\Data\WritingContext;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\Concerns\OutputsTypeScriptLiteral;
 
 class TypeScriptParameter implements TypeScriptNode
 {
+    use OutputsTypeScriptLiteral;
+
     public function __construct(
         public string $name,
         #[NodeVisitable]
@@ -21,7 +24,7 @@ class TypeScriptParameter implements TypeScriptNode
     public function write(WritingContext $context): string
     {
         $name = ! preg_match('/^[$_a-zA-Z][$_a-zA-Z0-9]*$/', $this->name)
-            ? "'{$this->name}'"
+            ? $this->outputLiteral($this->name)
             : $this->name;
 
         $spread = $this->isSpread ? '...' : '';

--- a/tests/.pest/snapshots/IntegrationTest/it_can_handle_the_integration_test_with_a_flat_file.snap
+++ b/tests/.pest/snapshots/IntegrationTest/it_can_handle_the_integration_test_with_a_flat_file.snap
@@ -1,4 +1,4 @@
-export type Enum = "yes" | "no";
+export type Enum = 'yes' | 'no';
 export type IntegrationClass = {
 string: string,
 nullable: string | null,

--- a/tests/.pest/snapshots/IntegrationTest/it_can_handle_the_integration_test_with_a_module_structure.snap
+++ b/tests/.pest/snapshots/IntegrationTest/it_can_handle_the_integration_test_with_a_module_structure.snap
@@ -1,5 +1,5 @@
 import { LevelUpClass } from './Level';
-export type Enum = "yes" | "no";
+export type Enum = 'yes' | 'no';
 export type IntegrationClass = {
 string: string,
 nullable: string | null,

--- a/tests/.pest/snapshots/IntegrationTest/it_can_handle_the_integration_test_with_a_namespaced_file.snap
+++ b/tests/.pest/snapshots/IntegrationTest/it_can_handle_the_integration_test_with_a_namespaced_file.snap
@@ -3,7 +3,7 @@ namespace TypeScriptTransformer {
 namespace Tests {
 namespace Fakes {
 namespace Integration {
-export type Enum = "yes" | "no";
+export type Enum = 'yes' | 'no';
 export type IntegrationClass = {
 string: string,
 nullable: string | null,

--- a/tests/Transformers/EnumTransformerTest.php
+++ b/tests/Transformers/EnumTransformerTest.php
@@ -52,7 +52,7 @@ TS);
 
 it('can transform a string backed enum into a union enum', function () {
     expect(classesToTypeScript([StringBackedEnum::class], new EnumTransformer()))
-        ->toBe('export type StringBackedEnum = "john" | "paul" | "george" | "ringo";' . "\n");
+        ->toBe("export type StringBackedEnum = 'john' | 'paul' | 'george' | 'ringo';" . "\n");
 });
 
 it('can transform a string backed enum into a native enum', function () {

--- a/tests/TypeScript/TypeScriptArrayExpressionTest.php
+++ b/tests/TypeScript/TypeScriptArrayExpressionTest.php
@@ -17,5 +17,5 @@ it('can write an array expression with elements', function () {
         new TypeScriptLiteral('c'),
     ]);
 
-    expect($node->write(new WritingContext([])))->toBe('["a", "b", "c"]');
+    expect($node->write(new WritingContext([])))->toBe("['a', 'b', 'c']");
 });

--- a/tests/TypeScript/TypeScriptCallExpressionTest.php
+++ b/tests/TypeScript/TypeScriptCallExpressionTest.php
@@ -11,7 +11,7 @@ it('can write a call expression without generics', function () {
         [new TypeScriptLiteral('index')],
     );
 
-    expect($node->write(new WritingContext([])))->toBe('createAction("index")');
+    expect($node->write(new WritingContext([])))->toBe("createAction('index')");
 });
 
 it('can write a call expression with generics', function () {
@@ -21,7 +21,7 @@ it('can write a call expression with generics', function () {
         genericTypes: [new TypeScriptIdentifier('UserParams')],
     );
 
-    expect($node->write(new WritingContext([])))->toBe('createAction<UserParams>("index")');
+    expect($node->write(new WritingContext([])))->toBe("createAction<UserParams>('index')");
 });
 
 it('can write a call expression with no arguments', function () {

--- a/tests/TypeScript/TypeScriptIndexedAccessTest.php
+++ b/tests/TypeScript/TypeScriptIndexedAccessTest.php
@@ -11,7 +11,7 @@ it('can write an indexed access with a single segment', function () {
         [new TypeScriptLiteral('name')],
     );
 
-    expect($node->write(new WritingContext([])))->toBe('User["name"]');
+    expect($node->write(new WritingContext([])))->toBe("User['name']");
 });
 
 it('can write an indexed access with multiple segments', function () {
@@ -20,5 +20,5 @@ it('can write an indexed access with multiple segments', function () {
         [new TypeScriptLiteral('address'), new TypeScriptLiteral('city')],
     );
 
-    expect($node->write(new WritingContext([])))->toBe('User["address"]["city"]');
+    expect($node->write(new WritingContext([])))->toBe("User['address']['city']");
 });

--- a/tests/TypeScript/TypeScriptLiteralTest.php
+++ b/tests/TypeScript/TypeScriptLiteralTest.php
@@ -3,13 +3,23 @@
 use Spatie\TypeScriptTransformer\Data\WritingContext;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptLiteral;
 
-it('can write literal values', function (int|string|bool $value, string $expected) {
+it('can write literal values', function (int|string|float|bool|null $value, string $expected) {
     $node = new TypeScriptLiteral($value);
 
     expect($node->write(new WritingContext([])))->toBe($expected);
 })->with(function () {
-    yield 'string' => ['hello', '"hello"'];
+    yield 'string' => ['hello', "'hello'"];
     yield 'int' => [42, '42'];
+    yield 'negative int' => [-7, '-7'];
+    yield 'float' => [3.14, '3.14'];
     yield 'true' => [true, 'true'];
     yield 'false' => [false, 'false'];
+    yield 'null' => [null, 'null'];
+    yield 'string with backslash' => ['App\\Models\\User', "'App\\\\Models\\\\User'"];
+    yield 'string with single quote' => ["it's", "'it\\'s'"];
+    yield 'string with newline' => ["line1\nline2", "'line1\\nline2'"];
+    yield 'string with carriage return' => ["a\rb", "'a\\rb'"];
+    yield 'string with tab' => ["a\tb", "'a\\tb'"];
+    yield 'string with forward slash' => ['image/png', "'image/png'"];
+    yield 'string with mixed escapes' => ["a\\b'c\nd", "'a\\\\b\\'c\\nd'"];
 });

--- a/tests/TypeScript/TypeScriptParameterTest.php
+++ b/tests/TypeScript/TypeScriptParameterTest.php
@@ -31,5 +31,5 @@ it('can write a parameter with default value', function () {
         defaultValue: new TypeScriptLiteral('world'),
     );
 
-    expect($node->write(new WritingContext([])))->toBe('name: string = "world"');
+    expect($node->write(new WritingContext([])))->toBe("name: string = 'world'");
 });

--- a/tests/TypeScript/TypeScriptVariableDeclarationTest.php
+++ b/tests/TypeScript/TypeScriptVariableDeclarationTest.php
@@ -8,7 +8,7 @@ use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptVariableDeclaration;
 it('can write a const declaration', function () {
     $node = TypeScriptVariableDeclaration::const('name', new TypeScriptLiteral('world'));
 
-    expect($node->write(new WritingContext([])))->toBe('const name = "world"');
+    expect($node->write(new WritingContext([])))->toBe("const name = 'world'");
 });
 
 it('can write a let declaration', function () {
@@ -30,5 +30,5 @@ it('can write a declaration with type annotation', function () {
         type: new TypeScriptString(),
     );
 
-    expect($node->write(new WritingContext([])))->toBe('const name: string = "world"');
+    expect($node->write(new WritingContext([])))->toBe("const name: string = 'world'");
 });


### PR DESCRIPTION
## Summary

- Introduces an `OutputsTypeScriptLiteral` trait that centralizes how scalar values are written as TypeScript literals (`string`, `int`, `float`, `bool`, `null`).
- Strings are escaped with a hand-rolled map (`\`, `'`, `\n`, `\r`, `\t`) and wrapped in single quotes, fixing invalid TypeScript output for values like `App\Models\User` or `it's`.
- Replaces inline interpolation in `TypeScriptLiteral`, `TypeScriptEnum`, `TypeScriptIdentifier`, `TypeScriptParameter`, and `TypeScriptImport`, removing four duplicated quoting sites that all had the same hazard.
- `TypeScriptLiteral` now emits single-quoted strings (previously double-quoted via `json_encode`), bringing it in line with the rest of the generated output. As a side benefit, the slash-escaping problem from `json_encode` (e.g. `image\/png`) is gone, since the trait does not use `json_encode` at all.

## Supersedes

- #138 by @pataar — fixed backslash and single-quote escaping for enum string values. Same bug class is now solved at the trait level for every literal output site.
- #148 by @bram-pkg — disabled slash escaping in `TypeScriptLiteral`. Behavior is preserved by removing `json_encode` entirely from the literal write path.

Thanks to both contributors for surfacing these issues.

## Notes

- `TypeScriptLiteral` now also accepts `float` and `null`, which previously errored at the constructor.
- Existing tests, snapshots, and the integration test were updated for the single-quote output change.