### PR TITLE
Add withoutManifest() option to skip manifest file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ psalm.xml
 vendor
 .php-cs-fixer.cache
 .claude/settings.local.json
+.phpactor.json
 
 .phpunit.cache

--- a/docs/advanced/the-manifest-file.md
+++ b/docs/advanced/the-manifest-file.md
@@ -1,0 +1,39 @@
+---
+title: The manifest file
+weight: 5
+---
+
+When TypeScript transformer writes your types to disk, it also writes a `typescript-transformer-manifest.json` file in
+your output directory. This manifest keeps track of every generated file together with a hash of its contents.
+
+On the next run, the manifest is used to:
+
+- Skip rewriting files whose contents did not change (faster runs, fewer file modifications)
+- Delete files that were generated before but are no longer produced (cleaning up renamed or removed types)
+
+In most cases you'll want to keep the manifest around. It makes runs cheaper and keeps your output directory in sync with
+your PHP classes.
+
+## Disabling the manifest
+
+Sometimes the manifest gets in the way. A few examples:
+
+- The output directory is a committed git submodule, where the manifest shows up as an unexpected tracked file
+- The output directory is version-controlled and you prefer a clean diff
+- You don't need manifest-based caching (for example in CI, where every run starts from a clean checkout)
+
+You can opt out of manifest generation with `withoutManifest()`:
+
+```php
+$config
+    ->outputDirectory(resource_path('frontend/types'))
+    ->writer(new GlobalNamespaceWriter('generated.d.ts'))
+    ->withoutManifest();
+```
+
+When the manifest is disabled, every file is written on every run and no `typescript-transformer-manifest.json` is
+created.
+
+Keep in mind that disabling the manifest also disables the cleanup of stale files. Because there is no record of what was
+written previously, files for types that you rename or remove are left behind in the output directory. You'll need to
+clean those up yourself, for example by emptying the output directory before each run.

--- a/src/Actions/WriteFilesAction.php
+++ b/src/Actions/WriteFilesAction.php
@@ -18,20 +18,6 @@ class WriteFilesAction
      */
     public function execute(array &$writeableFiles): void
     {
-        if (! $this->config->generateManifest) {
-            foreach ($writeableFiles as $index => $writeableFile) {
-                $this->writeFile($writeableFile);
-
-                $writeableFiles[$index] = new WriteableFile(
-                    $writeableFile->path,
-                    $writeableFile->contents,
-                    changed: true
-                );
-            }
-
-            return;
-        }
-
         $oldManifest = $this->fetchManifest();
 
         foreach ($writeableFiles as $index => $writeableFile) {
@@ -78,6 +64,10 @@ class WriteFilesAction
     /** @return array<string, string>|null */
     protected function fetchManifest(): ?array
     {
+        if (! $this->config->generateManifest) {
+            return null;
+        }
+
         $manifestPath = $this->getManifestPath();
 
         if (! file_exists($manifestPath)) {
@@ -142,6 +132,10 @@ class WriteFilesAction
 
     protected function storeManifest(array $manifest): void
     {
+        if (! $this->config->generateManifest) {
+            return;
+        }
+
         file_put_contents(
             $this->getManifestPath(),
             json_encode($manifest, JSON_PRETTY_PRINT)

--- a/src/Actions/WriteFilesAction.php
+++ b/src/Actions/WriteFilesAction.php
@@ -18,6 +18,20 @@ class WriteFilesAction
      */
     public function execute(array &$writeableFiles): void
     {
+        if (! $this->config->generateManifest) {
+            foreach ($writeableFiles as $index => $writeableFile) {
+                $this->writeFile($writeableFile);
+
+                $writeableFiles[$index] = new WriteableFile(
+                    $writeableFile->path,
+                    $writeableFile->contents,
+                    changed: true
+                );
+            }
+
+            return;
+        }
+
         $oldManifest = $this->fetchManifest();
 
         foreach ($writeableFiles as $index => $writeableFile) {

--- a/src/TypeScriptTransformerConfig.php
+++ b/src/TypeScriptTransformerConfig.php
@@ -28,6 +28,7 @@ class TypeScriptTransformerConfig
         public readonly array $connectedVisitorClosures = [],
         public readonly array $transformers = [],
         public readonly array $configPaths = [],
+        public readonly bool $generateManifest = true,
     ) {
     }
 }

--- a/src/TypeScriptTransformerConfigFactory.php
+++ b/src/TypeScriptTransformerConfigFactory.php
@@ -45,6 +45,7 @@ class TypeScriptTransformerConfigFactory
         protected array $providedVisitorClosures = [],
         protected array $connectedVisitorClosures = [],
         protected array $configPaths = [],
+        protected bool $generateManifest = true,
     ) {
     }
 
@@ -216,6 +217,13 @@ class TypeScriptTransformerConfigFactory
         return $this;
     }
 
+    public function withoutManifest(): self
+    {
+        $this->generateManifest = false;
+
+        return $this;
+    }
+
     public function get(): TypeScriptTransformerConfig
     {
         $this->ensureConfigIsValid();
@@ -266,7 +274,8 @@ class TypeScriptTransformerConfigFactory
             $this->providedVisitorClosures,
             $this->connectedVisitorClosures,
             $transformers,
-            $this->configPaths
+            $this->configPaths,
+            $this->generateManifest,
         );
     }
 

--- a/tests/Actions/WriteFilesActionTest.php
+++ b/tests/Actions/WriteFilesActionTest.php
@@ -136,6 +136,63 @@ it('will always create a manifest file', function () {
     expect(file_exists($this->temporaryDirectory->path('typescript-transformer-manifest.json')))->toBeTrue();
 });
 
+it('will not create a manifest file when manifest generation is disabled', function () {
+    $fileA = new WriteableFile('fileA.ts', 'fileA contents');
+    $fileB = new WriteableFile('fileB.ts', 'fileB contents');
+
+    $config = TypeScriptTransformerConfigFactory::create()
+        ->outputDirectory($this->temporaryDirectory->path())
+        ->withoutManifest()
+        ->get();
+
+    $files = [$fileA, $fileB];
+    (new WriteFilesAction($config))->execute($files);
+
+    expect(file_get_contents($this->temporaryDirectory->path('fileA.ts')))->toBe('fileA contents');
+    expect(file_get_contents($this->temporaryDirectory->path('fileB.ts')))->toBe('fileB contents');
+    expect(file_exists($this->temporaryDirectory->path('typescript-transformer-manifest.json')))->toBeFalse();
+});
+
+it('marks every file as changed when manifest generation is disabled', function () {
+    $fileA = new WriteableFile('fileA.ts', 'fileA contents');
+    $fileB = new WriteableFile('fileB.ts', 'fileB contents');
+
+    $config = TypeScriptTransformerConfigFactory::create()
+        ->outputDirectory($this->temporaryDirectory->path())
+        ->withoutManifest()
+        ->get();
+
+    $files = [$fileA, $fileB];
+    (new WriteFilesAction($config))->execute($files);
+
+    expect($files[0]->changed)->toBeTrue();
+    expect($files[1]->changed)->toBeTrue();
+
+    $files = [$fileA, $fileB];
+    (new WriteFilesAction($config))->execute($files);
+
+    expect($files[0]->changed)->toBeTrue();
+    expect($files[1]->changed)->toBeTrue();
+});
+
+it('will not delete stale files when manifest generation is disabled', function () {
+    $fileA = new WriteableFile('fileA.ts', 'fileA contents');
+    $fileB = new WriteableFile('fileB.ts', 'fileB contents');
+
+    $config = TypeScriptTransformerConfigFactory::create()
+        ->outputDirectory($this->temporaryDirectory->path())
+        ->withoutManifest()
+        ->get();
+
+    $files = [$fileA, $fileB];
+    (new WriteFilesAction($config))->execute($files);
+
+    $files = [$fileB];
+    (new WriteFilesAction($config))->execute($files);
+
+    expect(file_exists($this->temporaryDirectory->path('fileA.ts')))->toBeTrue();
+});
+
 it('marks only changed files in the array', function () {
     $fileA = new WriteableFile('fileA.ts', 'fileA contents');
     $fileB = new WriteableFile('fileB.ts', 'fileB contents');


### PR DESCRIPTION
## What this does

Adds a `withoutManifest()` method to `TypeScriptTransformerConfigFactory` that allows opting out of manifest file generation.

## Why

The `typescript-transformer-manifest.json` file is useful for caching (it prevents rewriting unchanged output files), but it can be undesirable in some workflows:

- When the output directory is a committed git submodule — the manifest shows up as an unexpected new tracked file
- When the output directory is version-controlled and a clean diff is preferred
- When manifest-based caching is not needed (e.g. in CI)

## Usage

```php
$config
    ->outputDirectory(resource_path('frontend/types'))
    ->writer(new GlobalNamespaceWriter('generated.d.ts'))
    ->withoutManifest();
```

## Changes

- `TypeScriptTransformerConfig` — added `bool $generateManifest = true` property
- `TypeScriptTransformerConfigFactory` — added `withoutManifest()` method and `bool $generateManifest = true` field, passed through to config
- `WriteFilesAction` — when `generateManifest` is `false`, skips manifest read/write and writes all files directly