### PR TITLE
Add Conductor repository settings

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "composer install"
+run = "composer test"
+run_mode = "concurrent"


### PR DESCRIPTION
Adds `.conductor/settings.toml` so Conductor workspaces are set up and runnable out of the box. The setup script runs `composer install` and the Run button maps to `composer test` (the Pest suite), with concurrent run mode since the library has no shared port or local resource.