### PR TITLE
Fix BetterReflection attribute instantiation in watch mode

### DIFF
--- a/src/PhpNodes/PhpAttributeNode.php
+++ b/src/PhpNodes/PhpAttributeNode.php
@@ -51,9 +51,7 @@ class PhpAttributeNode
 
         $className = $this->reflection->getName();
 
-        $this->initializeNamedArguments();
-
-        return (new $className())(...$this->namedArguments);
+        return new $className(...$this->getRawArguments());
     }
 
     /** @return array<string, mixed> */

--- a/tests/PhpNodes/PhpAttributeNodeTest.php
+++ b/tests/PhpNodes/PhpAttributeNodeTest.php
@@ -1,8 +1,13 @@
 <?php
 
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\DefaultReflector;
+use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpAttributeNode;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\ComplexAttribute;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\SimpleAttribute;
+use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\TypeScriptAttributedClass;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\VariadicAttribute;
 
 it('can check and get named arguments from a simple attribute', function () {
@@ -112,6 +117,20 @@ it('can use variadic parameters', function () {
     expect($attributeNode->hasArgument('variadic'))->toBeTrue();
     expect($attributeNode->getArgument('variadic'))->toBe([2, 3, 4]);
 });
+
+it('can instantiate an attribute with constructor arguments reflected through BetterReflection', function () {
+    $astLocator = (new BetterReflection())->astLocator();
+
+    $attribute = (new DefaultReflector(new AutoloadSourceLocator($astLocator)))
+        ->reflectClass(TypeScriptAttributedClass::class)
+        ->getAttributesByName(TypeScript::class)[0];
+
+    $instance = (new PhpAttributeNode($attribute))->newInstance();
+
+    expect($instance)->toBeInstanceOf(TypeScript::class);
+    expect($instance->name)->toBe('JustAnotherName');
+});
+
 function createAttributeNode(string $className, string $attributeClass): PhpAttributeNode
 {
     $reflection = new ReflectionClass($className);


### PR DESCRIPTION
Fixes #154. In watch mode, attributes are reflected through Roave BetterReflection, and `PhpAttributeNode::newInstance()` constructed the attribute with no arguments before invoking the result as a callable, which threw `ArgumentCountError` for any attribute with required constructor arguments (such as `#[LiteralTypeScriptType('string[]')]`). The arguments are now spread straight into the constructor, letting PHP bind positional, named, default, and variadic values itself. Added a regression test that instantiates a constructor-argument attribute reflected through BetterReflection, the path that was previously untested.