### PR TITLE
Modify transformer example in first-run.md

### DIFF
--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -49,7 +49,7 @@ $config->transformer(AttributedClassTransformer::class);
 Since transformers are just PHP classes, you can also pass them arguments when initializing them:
 
 ```php
-$config->transformer(new EnumTransformer(useNativeEnums: true)); // transformers enums as TypeScript native enums and not as a union of strings
+$config->transformer(new EnumTransformer(useUnionEnums: false)); // transformers enums as TypeScript native enums and not as a union of strings
 ```
 
 Quick note: transformers are executed in the order they are registered in the configuration, when a transformer cannot


### PR DESCRIPTION
Updated the example to use 'useUnionEnums: false' instead of the non existing 'useNativeEnums:'

`useNativeEnums` does not exist in the `EnumTransformer`:

```php
public function __construct(
        public bool $useUnionEnums = true,
        public EnumProvider $enumProvider = new PhpEnumProvider()
    ) {
    }
```

Two more suggestions:
1. A dedicated page for Enums, it was hard to find how to set this up.
2. `useNativeEnums` with default false makes more sense than `useUnionEnums` with default true, like the docs initially suggested. (But its an opinion)