### PR TITLE
Resolve inherited constructor docblocks against the declaring class

### DIFF
--- a/src/Transformers/ClassTransformer.php
+++ b/src/Transformers/ClassTransformer.php
@@ -150,7 +150,10 @@ abstract class ClassTransformer implements Transformer
         $constructorAnnotations = $this->getConstructorAnnotations($phpClassNode);
 
         if (array_key_exists($name, $constructorAnnotations)) {
-            return [$constructorAnnotations[$name], $phpClassNode];
+            return [
+                $constructorAnnotations[$name],
+                $phpClassNode->getMethod('__construct')->getDeclaringClass(),
+            ];
         }
 
         $declaringClass = $phpPropertyNode->getDeclaringClass();

--- a/tests/Fakes/ChildWithInheritedConstructor.php
+++ b/tests/Fakes/ChildWithInheritedConstructor.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\TypeScriptTransformer\Tests\Fakes;
+
+class ChildWithInheritedConstructor extends ParentWithPropertyAnnotations
+{
+}

--- a/tests/Transformers/ClassTransformerTest.php
+++ b/tests/Transformers/ClassTransformerTest.php
@@ -11,6 +11,7 @@ use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpPropertyNode;
 use Spatie\TypeScriptTransformer\References\ClassStringReference;
 use Spatie\TypeScriptTransformer\References\PhpClassReference;
+use Spatie\TypeScriptTransformer\Tests\Fakes\ChildWithInheritedConstructor;
 use Spatie\TypeScriptTransformer\Tests\Fakes\ChildWithPropertyAnnotations;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericClass;
 use Spatie\TypeScriptTransformer\Tests\Fakes\TypesToProvide\GenericContravariantClass;
@@ -194,6 +195,25 @@ it('resolves property annotations against the declaring class namespace', functi
             new TypeScriptProperty(new TypeScriptIdentifier('childItems'), $childUnion),
             new TypeScriptProperty(new TypeScriptIdentifier('childItemsFromClass'), $childUnion),
             new TypeScriptProperty(new TypeScriptIdentifier('childItemsFromConstructor'), $childUnion),
+            new TypeScriptProperty(new TypeScriptIdentifier('items'), $parentUnion),
+            new TypeScriptProperty(new TypeScriptIdentifier('itemsFromClass'), $parentUnion),
+            new TypeScriptProperty(new TypeScriptIdentifier('itemsFromConstructor'), $parentUnion),
+        ])
+    );
+});
+
+/// ChildWithInheritedConstructor needs its own file, an inline class would resolve against this file's imports and pass even with the bug present
+it('resolves inherited constructor annotations against the declaring class namespace', function () {
+    $parentUnion = new TypeScriptUnion([
+        new TypeScriptArray([new TypeScriptString()]),
+        new TypeScriptGeneric(
+            new TypeScriptReference(new ClassStringReference(GenericClass::class)),
+            [new TypeScriptNumber()],
+        ),
+    ]);
+
+    expect(transformSingle(ChildWithInheritedConstructor::class)->getNode()->type)->toEqual(
+        new TypeScriptObject([
             new TypeScriptProperty(new TypeScriptIdentifier('items'), $parentUnion),
             new TypeScriptProperty(new TypeScriptIdentifier('itemsFromClass'), $parentUnion),
             new TypeScriptProperty(new TypeScriptIdentifier('itemsFromConstructor'), $parentUnion),

--- a/tests/Transformers/ClassTransformerTest.php
+++ b/tests/Transformers/ClassTransformerTest.php
@@ -202,7 +202,6 @@ it('resolves property annotations against the declaring class namespace', functi
     );
 });
 
-/// ChildWithInheritedConstructor needs its own file, an inline class would resolve against this file's imports and pass even with the bug present
 it('resolves inherited constructor annotations against the declaring class namespace', function () {
     $parentUnion = new TypeScriptUnion([
         new TypeScriptArray([new TypeScriptString()]),
@@ -212,6 +211,7 @@ it('resolves inherited constructor annotations against the declaring class names
         ),
     ]);
 
+    /// ChildWithInheritedConstructor needs its own file, an inline class would resolve against this file's imports and pass even with the bug present
     expect(transformSingle(ChildWithInheritedConstructor::class)->getNode()->type)->toEqual(
         new TypeScriptObject([
             new TypeScriptProperty(new TypeScriptIdentifier('items'), $parentUnion),


### PR DESCRIPTION
A child class that does not declare its own constructor lost the docblock types on inherited promoted properties, so `array<SpanAggregationType>` came out as `unknown[]`.

Reflection returns the inherited parent constructor, so the `@param` annotation was found but paired with the child as the resolution context, and short class names were then looked up in the child file's use statements, which do not import them. This pairs the annotation with the constructor's declaring class instead, which resolves to the same class whenever a class declares its own constructor, so nothing changes there.

Fixes #160